### PR TITLE
Restore tracing span into the ThreadLocal in JdbcQueryExecutor

### DIFF
--- a/buildSrc/src/main/kotlin/CI.kt
+++ b/buildSrc/src/main/kotlin/CI.kt
@@ -3,7 +3,7 @@ import java.lang.Boolean.parseBoolean
 object Ci {
 
     private const val SNAPSHOT_BASE = "0.7.0"
-    private const val RELEASE_VERSION = "0.6.12"
+    private const val RELEASE_VERSION = "0.6.13"
     private val githubSha = System.getenv("GITHUB_SHA") ?: "latest"
 
     val publishRelease = System.getProperty("release", "true").let(::parseBoolean)

--- a/eva-persistence-jdbc/build.gradle.kts
+++ b/eva-persistence-jdbc/build.gradle.kts
@@ -8,9 +8,13 @@ dependencies {
     api(libs.kotlin_coroutines)
 
     api(project(eva.eva_persistence))
+    api(project(eva.eva_tracing))
 
     implementation(libs.kotlin_stdlib)
 
     implementation(libs.postgres)
     implementation(libs.jooq)
+
+    implementation(libs.opentracing_api)
+    implementation(libs.opentracing_noop)
 }

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
@@ -10,7 +10,7 @@ import kotlin.coroutines.coroutineContext
  *
  * After the execution of the block, the original active span is restored.
  *
- * `block` is specifically made non-suspending to make use of ThreadLocal-stored spans.
+ * `block` is made non-suspending on purpose, to make sure that ThreadLocal-stored spans are not lost on context switch.
  */
 suspend fun <T> Tracer.withRestoredThreadLocalSpan(block: () -> T): T {
     val previousSpan: Span? = activeSpan()

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
@@ -13,7 +13,7 @@ import kotlin.coroutines.coroutineContext
  * `block` is specifically made non-suspending to make use of ThreadLocal-stored spans.
  */
 suspend fun <T> Tracer.withRestoredThreadLocalSpan(block: () -> T): T {
-    val activeSpan: Span? = activeSpan()
+    val previousSpan: Span? = activeSpan()
 
     val coroutineSpan = coroutineContext[ActiveSpanElement]
     if (coroutineSpan != null) {
@@ -24,7 +24,7 @@ suspend fun <T> Tracer.withRestoredThreadLocalSpan(block: () -> T): T {
         return block()
     } finally {
         if (coroutineSpan != null) {
-            activateSpan(activeSpan)
+            activateSpan(previousSpan)
         }
     }
 }

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/WithRestoredThreadLocalSpan.kt
@@ -1,0 +1,30 @@
+package com.razz.eva.tracing
+
+import io.opentracing.Span
+import io.opentracing.Tracer
+import kotlin.coroutines.coroutineContext
+
+/**
+ * Extracts active span from the coroutine context and restores it into the `tracer`'s ThreadLocal variable,
+ * so it can be accessed later downstream in non-suspending functions.
+ *
+ * After the execution of the block, the original active span is restored.
+ *
+ * `block` is specifically made non-suspending to make use of ThreadLocal-stored spans.
+ */
+suspend fun <T> Tracer.withRestoredThreadLocalSpan(block: () -> T): T {
+    val activeSpan: Span? = activeSpan()
+
+    val coroutineSpan = coroutineContext[ActiveSpanElement]
+    if (coroutineSpan != null) {
+        activateSpan(coroutineSpan.span)
+    }
+
+    try {
+        return block()
+    } finally {
+        if (coroutineSpan != null) {
+            activateSpan(activeSpan)
+        }
+    }
+}


### PR DESCRIPTION
`ThreadLocal`-stored spans can be later used for adding traces for queries, connection acquisition, connection release, etc.