### PR TITLE
set maxEventPayloadSize in events repository and reject events with payload exceeding it

### DIFF
--- a/buildSrc/src/main/kotlin/CI.kt
+++ b/buildSrc/src/main/kotlin/CI.kt
@@ -3,7 +3,7 @@ import java.lang.Boolean.parseBoolean
 object Ci {
 
     private const val SNAPSHOT_BASE = "0.8.0"
-    private const val RELEASE_VERSION = "0.7.3"
+    private const val RELEASE_VERSION = "0.7.4"
     private val githubSha = System.getenv("GITHUB_SHA") ?: "latest"
 
     val publishRelease = System.getProperty("release", "true").let(::parseBoolean)

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
@@ -54,4 +54,14 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
     class PersistingGenericException(
         override val cause: Throwable
     ) : PersistenceException("Persisting failed")
+
+    class EventPayloadTooLargeException(
+        val modelId: ModelId<*>,
+        val modelEventId: UUID,
+        val eventId: UUID,
+        val payloadSize: Int,
+        val maxEventPayloadSize: Int,
+    ) : PersistenceException(
+        "Event [eventId=$eventId, modelEventId=$modelEventId] payload size is $payloadSize which exceeds maxEventPayloadSize $maxEventPayloadSize bytes"
+    )
 }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
@@ -62,6 +62,8 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
         val payloadSize: Int,
         val maxEventPayloadSize: Int,
     ) : PersistenceException(
-        "Event [eventId=$eventId, modelEventId=$modelEventId] payload size is $payloadSize which exceeds maxEventPayloadSize $maxEventPayloadSize bytes"
+        "Event [eventId=$eventId, modelEventId=$modelEventId] " +
+            "payload size is $payloadSize which exceeds " +
+            "maxEventPayloadSize $maxEventPayloadSize bytes"
     )
 }

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
@@ -9,6 +9,7 @@ import com.razz.eva.events.db.tables.ModelEvents.MODEL_EVENTS
 import com.razz.eva.events.db.tables.UowEvents.UOW_EVENTS
 import com.razz.eva.events.db.tables.records.ModelEventsRecord
 import com.razz.eva.events.db.tables.records.UowEventsRecord
+import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.PersistenceException.UniqueUowEventRecordViolationException
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.eva.repository.Fake.FakeModelEvent
@@ -33,7 +34,8 @@ import kotlin.coroutines.coroutineContext
 class JooqEventRepository(
     private val queryExecutor: QueryExecutor,
     private val dslContext: DSLContext,
-    private val tracer: Tracer
+    private val tracer: Tracer,
+    private val maxEventPayloadSize: Int = 1024 * 1024,
 ) : EventRepository {
 
     override suspend fun warmup() {
@@ -58,6 +60,19 @@ class JooqEventRepository(
         eventId: ModelEventId,
         modelEvent: ModelEvent<*>
     ): ModelEventsRecord {
+        val payloadString = modelEvent.payload(uowEvent.principal).toString()
+        val payloadSize = payloadString.toByteArray(Charsets.UTF_8).size
+
+        if (payloadSize > maxEventPayloadSize) {
+            throw PersistenceException.EventPayloadTooLargeException(
+                modelId = modelEvent.modelId,
+                modelEventId = eventId.uuidValue(),
+                eventId = uowEvent.id.uuidValue(),
+                payloadSize = payloadSize,
+                maxEventPayloadSize = maxEventPayloadSize,
+            )
+        }
+
         return ModelEventsRecord().apply {
             id = eventId.uuidValue()
             uowId = uowEvent.id.uuidValue()
@@ -65,7 +80,7 @@ class JooqEventRepository(
             name = modelEvent.eventName()
             modelName = modelEvent.modelName
             occurredAt = uowEvent.occurredAt
-            payload = modelEvent.payload(uowEvent.principal).toString()
+            payload = payloadString
         }
     }
 

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
@@ -418,7 +418,7 @@ class JooqEventRepositorySpec : BehaviorSpec({
                 eventRepo.add(uowEvent)
             }
 
-            Then("It should reject the event and throw an IllegalStateException") {
+            Then("It should reject the event and throw an EventPayloadTooLargeException") {
                 exception.eventId shouldBe eventId.uuidValue()
                 exception.modelEventId shouldBe modelEventId.uuidValue()
                 exception.payloadSize shouldBe 1217

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
@@ -392,7 +392,7 @@ class JooqEventRepositorySpec : BehaviorSpec({
         val queryExecutor = FakeMemorizingQueryExecutor()
         val eventRepo = JooqEventRepository(queryExecutor, dslContext, tracer, 100)
 
-        When("Max payload size is set to 100 bytes") {
+        When("trying to insert an event with a payload size exceeding the maxEventPayloadSize") {
             val params = Params(1, "Nik", IdempotencyKey.random())
             val eventId = UowEvent.Id(randomUUID())
             val departmentId = randomDepartmentId()
@@ -418,7 +418,7 @@ class JooqEventRepositorySpec : BehaviorSpec({
                 eventRepo.add(uowEvent)
             }
 
-            Then("It should reject the event and throw an EventPayloadTooLargeException") {
+            Then("it should reject the event and throw an EventPayloadTooLargeException") {
                 exception.eventId shouldBe eventId.uuidValue()
                 exception.modelEventId shouldBe modelEventId.uuidValue()
                 exception.payloadSize shouldBe 1217


### PR DESCRIPTION
- Introduced a new property maxEventPayloadSize to JooqEventRepository.
- The default is set to 1MB.
- Any event with a payload exceeding this size will be reject with an exception EventPayloadTooLargeException.