### PR TITLE
[WIP] EVA-PIMP dont propagate non modified fields to sql

### DIFF
--- a/eva-domain/src/main/kotlin/com/razz/eva/domain/EntityState.kt
+++ b/eva-domain/src/main/kotlin/com/razz/eva/domain/EntityState.kt
@@ -39,6 +39,7 @@ sealed class EntityState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
 
     class PersistentState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> private constructor(
         version: Version,
+        internal val proto: Any,
     ) : EntityState<ID, E>(version, listOf()) {
 
         init {
@@ -48,14 +49,15 @@ sealed class EntityState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         }
 
         override fun raiseEvent0(newEvents: List<E>): DirtyState<ID, E> {
-            return dirtyState(version, newEvents)
+            return dirtyState(version, newEvents, proto)
         }
 
         companion object {
             fun <ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> persistentState(
                 version: Version,
+                proto: Any,
             ): PersistentState<ID, E> {
-                return PersistentState(version)
+                return PersistentState(version, proto)
             }
         }
     }
@@ -63,6 +65,7 @@ sealed class EntityState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
     class DirtyState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> private constructor(
         version: Version,
         events: Collection<E>,
+        internal val proto: Any,
     ) : EntityState<ID, E>(version, events) {
 
         init {
@@ -72,15 +75,16 @@ sealed class EntityState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         }
 
         override fun raiseEvent0(newEvents: List<E>): DirtyState<ID, E> {
-            return DirtyState(version, occurredEvents + newEvents)
+            return DirtyState(version, occurredEvents + newEvents, proto)
         }
 
         companion object {
             internal fun <ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> dirtyState(
                 version: Version,
                 events: Collection<E>,
+                proto: Any,
             ): DirtyState<ID, E> {
-                return DirtyState(version, events)
+                return DirtyState(version, events, proto)
             }
         }
     }

--- a/eva-domain/src/main/kotlin/com/razz/eva/domain/Model.kt
+++ b/eva-domain/src/main/kotlin/com/razz/eva/domain/Model.kt
@@ -18,4 +18,9 @@ abstract class Model<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
 
     protected fun raiseEvent(newEvent: E): EntityState<ID, E> =
         entityState.raiseEvent(newEvent)
+
+    fun <T> proto(): T? {
+        @Suppress("UNCHECKED_CAST")
+        return (entityState as? EntityState.DirtyState<ID, E>)?.proto as? T
+    }
 }

--- a/eva-domain/src/testFixtures/kotlin/com/razz/eva/domain/BubalehFixtures.kt
+++ b/eva-domain/src/testFixtures/kotlin/com/razz/eva/domain/BubalehFixtures.kt
@@ -25,7 +25,7 @@ object BubalehFixtures {
         taste = taste,
         producedOn = producedOn,
         volume = volume,
-        persistentState(V1)
+        persistentState(V1, Unit)
     )
 
     fun aConsumedBubaleh(
@@ -40,6 +40,6 @@ object BubalehFixtures {
         taste = taste,
         producedOn = producedOn,
         volume = volume,
-        persistentState(V1)
+        persistentState(V1, Unit)
     )
 }

--- a/eva-domain/src/testFixtures/kotlin/com/razz/eva/domain/TestModel.kt
+++ b/eva-domain/src/testFixtures/kotlin/com/razz/eva/domain/TestModel.kt
@@ -101,13 +101,14 @@ sealed class TestModel private constructor(
             id: TestModelId = randomTestModelId(),
             param1: String?,
             param2: Long,
-            version: Version = V1
+            version: Version = V1,
+            proto: Any = Unit,
         ): CreatedTestModel {
             return CreatedTestModel(
                 id = id,
                 param1 = param1,
                 param2 = param2,
-                persistentState(version)
+                persistentState(version, proto)
             )
         }
     }

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryBatchingSpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryBatchingSpec.kt
@@ -226,7 +226,6 @@ class JooqBaseRepositoryBatchingSpec : BehaviorSpec({
                 When("Principal updating model") {
                     repo.update(updateContext, listOf(addedDep.rename("UPDATE TEST")))
                     val recordUpdatedAt = InstantConverter.instance.to(updateContext.startedAt)
-                    val boss = requireNotNull(dep1.boss)
 
                     Then(
                         "Query executor should receive record with RECORD_CREATED_AT and RECORD_UPDATED_AT" +
@@ -236,10 +235,6 @@ class JooqBaseRepositoryBatchingSpec : BehaviorSpec({
                         update.jooqQuery.getSQL(INLINED) shouldBe """
                             update "departments" set
                             "name" = 'UPDATE TEST',
-                            "boss" = cast('${boss.id}' as uuid),
-                            "headcount" = 1,
-                            "ration" = 'BUBALEH',
-                            "state" = cast('OWNED' as "departments_state"),
                             "record_updated_at" = timestamp '$recordUpdatedAt',
                             "version" = 2
                             where ("departments"."id" = cast('${dep1.id().id}' as uuid) and "departments"."version" = 1 and "departments"."ration" = 'BUBALEH')

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/PagingStrategySpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/PagingStrategySpec.kt
@@ -198,7 +198,7 @@ fun model(record: BubalehsRecord): Bubaleh {
             BubalehTaste.valueOf(record.taste),
             record.producedOn,
             BubalehBottleVol.valueOf(record.volume),
-            persistentState(V1),
+            persistentState(V1, record),
         )
         CONSUMED -> Bubaleh.Consumed(
             BubalehId(record.id),
@@ -206,7 +206,7 @@ fun model(record: BubalehsRecord): Bubaleh {
             BubalehTaste.valueOf(record.taste),
             record.producedOn,
             BubalehBottleVol.valueOf(record.volume),
-            persistentState(V1),
+            persistentState(V1, record),
         )
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
@@ -79,7 +79,7 @@ class PersistingSpec : BehaviorSpec({
     val oldDepId = randomDepartmentId()
     val boss1 = Employee(
         bossId1, Name("Nursultan", "N"), oldDepId, "nursultan@001.kz", BUBALEH,
-        persistentState(V1)
+        persistentState(V1, Unit)
     ).changeDepartment(department1)
 
     val departmentId2 = randomDepartmentId()
@@ -101,7 +101,7 @@ class PersistingSpec : BehaviorSpec({
     )
     val boss2 = Employee(
         bossId2, Name("Vladimir", "P"), oldDepId, "vladimir@001.ru", BUBALEH,
-        persistentState(V1)
+        persistentState(V1, Unit)
     ).changeDepartment(department2)
 
     val departmentId3 = randomDepartmentId()
@@ -112,7 +112,7 @@ class PersistingSpec : BehaviorSpec({
         headcount = 1,
         ration = BUBALEH,
         boss = bossId3,
-        entityState = persistentState(V1)
+        entityState = persistentState(V1, Unit)
     ).changeBoss(boss2)
 
     val params = Params("Nik")


### PR DESCRIPTION
We don't want to update entire set of fields on every model roundtip. We expect most of usecases to update only few fields of any model while leaving majority _ubtouched_. This could improve overall program throughput, shaving off up to several milliseconds when indexed columns are skipped (consider everyone's favourite `refs` with some `GIN` / `GIST` indices on top).