### PR TITLE
Add updatable entity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,17 +150,19 @@ data class Tag(
 ) : DeletableEntity()
 ```
 
-Entities can be added and deleted within the same Unit of Work as Models:
+Entities can be added, updated and deleted within the same Unit of Work as Models:
 ```kotlin
 override suspend fun tryPerform(principal: ServicePrincipal, params: Params): Changes<Unit> {
     return changes {
         update(department.addEmployee(employee))
         add(Tag(department.id().id, "employee-added", employee.id().toString()))
+        update(Tag(department.id().id, "last-modified", clock.instant().toString()))
+        delete(Tag(department.id().id, "vacant", "true"))
     }
 }
 ```
 
-Entity repositories extend `JooqBaseEntityRepository` or `JooqDeletableEntityRepository`:
+Entity repositories extend `JooqBaseEntityRepository`, `JooqUpdatableEntityRepository` or `JooqDeletableEntityRepository`:
 ```kotlin
 class TagRepository(
     queryExecutor: QueryExecutor,
@@ -405,7 +407,7 @@ Eva provides two fundamental building blocks for your domain: **Models** and **E
 
 #### Use Entity when:
 - The object's identity is defined by its **content/attributes** rather than a separate Id
-- You need simple **add/delete** operations without lifecycle management
+- You need simple **add/update/delete** operations without lifecycle management
 - The object represents **supplementary data** like tags, labels, allocations, or mappings
 - No domain events need to be emitted for changes
 - The object is essentially a **value object that needs persistence**
@@ -418,7 +420,7 @@ Eva provides two fundamental building blocks for your domain: **Models** and **E
 | Versioning | Yes (optimistic locking) | Yes (optimistic locking) | No |
 | Events | Emits `ModelEvent` on state changes | Emits `ModelEvent` on state changes | No events |
 | Owned children | No | Yes, via `ownedModels` | No |
-| Operations | `add`, `update`, `notChanged` | `add`, `update`, `notChanged` | `add`, `delete` |
+| Operations | `add`, `update`, `notChanged` | `add`, `update`, `notChanged` | `add`, `update`, `delete` |
 | Typical use | Core domain objects | Aggregate roots with children | Tags, labels, mappings |
 
 #### Example Decision
@@ -471,15 +473,17 @@ Model<ID, E> (abstract class)
 
 Entity (abstract class)
   └── CreatableEntity (abstract class)
-        └── DeletableEntity (abstract class)
-              └── Your deletable entities
+        └── UpdatableEntity (abstract class)
+              └── DeletableEntity (abstract class)
+                    └── Your deletable entities
 ```
 
 #### Entity Classes
 - `CreatableEntity`: Can be added via `add()` in ChangesDsl
-- `DeletableEntity`: Extends `CreatableEntity`, can also be deleted via `delete()` in ChangesDsl
+- `UpdatableEntity`: Extends `CreatableEntity`, can also be updated via `update()` in ChangesDsl
+- `DeletableEntity`: Extends `UpdatableEntity`, can also be deleted via `delete()` in ChangesDsl
 
-Use `CreatableEntity` for append-only data (audit logs, historical records). Use `DeletableEntity` when entities can be removed.
+Use `CreatableEntity` for append-only data (audit logs, historical records). Use `UpdatableEntity` when entity fields can change. Use `DeletableEntity` when entities can be removed.
 
 #### Repository Pattern
 Entity repositories follow the same pattern as Model repositories but without versioning:
@@ -491,8 +495,14 @@ interface EntityRepository<E : CreatableEntity> {
     suspend fun add(context: TransactionalContext, entities: List<E>): List<E>
 }
 
-// For entities that can be added and deleted
-interface DeletableEntityRepository<E : DeletableEntity> : EntityRepository<E> {
+// For entities that can be added and updated
+interface UpdatableEntityRepository<E : UpdatableEntity> : EntityRepository<E> {
+    suspend fun update(context: TransactionalContext, entity: E): E
+    suspend fun update(context: TransactionalContext, entities: List<E>): List<E>
+}
+
+// For entities that can be added, updated and deleted
+interface DeletableEntityRepository<E : DeletableEntity> : UpdatableEntityRepository<E> {
     suspend fun delete(context: TransactionalContext, entity: E): Boolean
     suspend fun delete(context: TransactionalContext, entities: List<E>): Int
 }
@@ -518,6 +528,7 @@ Models and Entities are persisted in the **same transaction**, ensuring consiste
 changes {
     update(department.addEmployee(employee))      // Model update
     add(Tag.tag(department.id().id, "new-hire", employee.name))  // Entity add
+    update(Tag.tag(department.id().id, "headcount", department.headcount.toString())) // Entity update
     delete(oldTag)                                 // Entity delete
 }
 // All changes committed atomically
@@ -695,6 +706,8 @@ Use the `verifyInOrder` function to start the verification process.
         // Entity verification (same methods, distinguished by type parameter)
         adds<Tag> { entity -> ... }
         addsEq(expectedTag)
+
+        updates<Tag> { entity -> ... }
         
         deletes<Tag> { entity -> ... }
         deletesEq(expectedTag)
@@ -706,7 +719,7 @@ Use the `verifyInOrder` function to start the verification process.
         returns { result -> ... }
     }
 ```
-The `adds` and `addsEq` methods work for both Models and Entities - the correct verification is chosen based on the type parameter. Entity-specific methods `deletes` and `deletesEq` are available for `DeletableEntity` types.
+The `adds`, `updates` and `addsEq` methods work for both Models and Entities -- the correct verification is chosen based on the type parameter. Entity-specific methods `deletes` and `deletesEq` are available for `DeletableEntity` types.
 
 You can check some examples [here](eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkDemoSpec.kt)
 

--- a/eva-domain/src/main/kotlin/com/razz/eva/domain/Entity.kt
+++ b/eva-domain/src/main/kotlin/com/razz/eva/domain/Entity.kt
@@ -15,7 +15,13 @@ abstract class Entity
 abstract class CreatableEntity : Entity()
 
 /**
- * Base class for entities that can be deleted via Unit of Work.
- * Deletable entities must also be creatable (you need to create an entity before you can delete it).
+ * Base class for entities that can be updated via Unit of Work.
+ * Updatable entities must also be creatable (you need to create an entity before you can update it).
  */
-abstract class DeletableEntity : CreatableEntity()
+abstract class UpdatableEntity : CreatableEntity()
+
+/**
+ * Base class for entities that can be deleted via Unit of Work.
+ * Deletable entities are also updatable and creatable.
+ */
+abstract class DeletableEntity : UpdatableEntity()

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/EntityRepos.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/EntityRepos.kt
@@ -3,6 +3,7 @@ package com.razz.eva.repository
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import kotlin.reflect.KClass
 
 class EntityRepos(
@@ -26,6 +27,15 @@ class EntityRepos(
         val repo = classToRepo[entity::class] ?: throw EntityRepositoryNotFoundException(entity)
         @Suppress("UNCHECKED_CAST")
         return repo as EntityRepository<E>
+    }
+
+    fun <E : UpdatableEntity> updatableRepoFor(entity: E): UpdatableEntityRepository<E> {
+        val repo = classToRepo[entity::class] ?: throw EntityRepositoryNotFoundException(entity)
+        if (repo !is UpdatableEntityRepository<*>) {
+            throw IllegalStateException("Repository for ${entity::class} does not support updates")
+        }
+        @Suppress("UNCHECKED_CAST")
+        return repo as UpdatableEntityRepository<E>
     }
 
     fun <E : DeletableEntity> deletableRepoFor(entity: E): DeletableEntityRepository<E> {

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/EntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/EntityRepository.kt
@@ -2,13 +2,13 @@ package com.razz.eva.repository
 
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
+import com.razz.eva.domain.UpdatableEntity
 
 /**
  * Repository interface for Entity persistence.
  *
  * Unlike [ModelRepository], entities:
  * - Have no explicit ID for lookup
- * - Can only be added (insert) or deleted, not updated
  * - Identity is determined by content
  */
 interface EntityRepository<E : CreatableEntity> {
@@ -19,9 +19,19 @@ interface EntityRepository<E : CreatableEntity> {
 }
 
 /**
+ * Extended repository for entities that support updates.
+ */
+interface UpdatableEntityRepository<E : UpdatableEntity> : EntityRepository<E> {
+
+    suspend fun update(context: TransactionalContext, entity: E): E
+
+    suspend fun update(context: TransactionalContext, entities: List<E>): List<E>
+}
+
+/**
  * Extended repository for entities that support deletion.
  */
-interface DeletableEntityRepository<E : DeletableEntity> : EntityRepository<E> {
+interface DeletableEntityRepository<E : DeletableEntity> : UpdatableEntityRepository<E> {
 
     suspend fun delete(context: TransactionalContext, entity: E): Boolean
 

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqDeletableEntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqDeletableEntityRepository.kt
@@ -11,14 +11,8 @@ abstract class JooqDeletableEntityRepository<E : DeletableEntity, R : BaseEntity
     private val queryExecutor: QueryExecutor,
     private val dslContext: DSLContext,
     private val table: Table<R>,
-) : JooqBaseEntityRepository<E, R>(queryExecutor, dslContext, table),
+) : JooqUpdatableEntityRepository<E, R>(queryExecutor, dslContext, table),
     DeletableEntityRepository<E> {
-
-    /**
-     * Derive the unique condition to identify this entity in the database.
-     * Typically based on composite primary key or unique constraint columns.
-     */
-    protected abstract fun entityCondition(entity: E): Condition
 
     override suspend fun delete(context: TransactionalContext, entity: E): Boolean {
         val deleteQuery = dslContext.deleteFrom(table)

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqUpdatableEntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqUpdatableEntityRepository.kt
@@ -1,0 +1,48 @@
+package com.razz.eva.repository
+
+import com.razz.eva.domain.UpdatableEntity
+import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.jooq.record.BaseEntityRecord
+import org.jooq.Condition
+import org.jooq.DSLContext
+import org.jooq.Table
+
+abstract class JooqUpdatableEntityRepository<E : UpdatableEntity, R : BaseEntityRecord>(
+    private val queryExecutor: QueryExecutor,
+    private val dslContext: DSLContext,
+    private val table: Table<R>,
+) : JooqBaseEntityRepository<E, R>(queryExecutor, dslContext, table),
+    UpdatableEntityRepository<E> {
+
+    /**
+     * Derive the unique condition to identify this entity in the database.
+     * Typically based on composite primary key or unique constraint columns.
+     */
+    protected abstract fun entityCondition(entity: E): Condition
+
+    override suspend fun update(context: TransactionalContext, entity: E): E {
+        val record = toRecord(entity)
+        val updateQuery = dslContext.updateQuery(table).apply {
+            setRecord(record)
+            addConditions(entityCondition(entity))
+        }
+        val updated = queryExecutor.executeStore(
+            dslContext = dslContext,
+            jooqQuery = updateQuery,
+            table = table,
+        )
+        return when (updated.size) {
+            0 -> throw IllegalStateException("Entity not found for update")
+            1 -> fromRecord(updated.first())
+            else -> throw IllegalStateException(
+                "Update affected ${updated.size} rows, expected 1",
+            )
+        }
+    }
+
+    override suspend fun update(context: TransactionalContext, entities: List<E>): List<E> {
+        if (entities.isEmpty()) throw IllegalArgumentException("No entities provided for update")
+        if (entities.size == 1) return listOf(update(context, entities.first()))
+        return entities.map { update(context, it) }
+    }
+}

--- a/eva-test/src/main/kotlin/com/razz/eva/test/repository/WritableEntityRepository.kt
+++ b/eva-test/src/main/kotlin/com/razz/eva/test/repository/WritableEntityRepository.kt
@@ -2,6 +2,7 @@ package com.razz.eva.test.repository
 
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.repository.EntityRepos
@@ -38,6 +39,20 @@ class WritableEntityRepository(
         txStartedAt: Instant = clock.instant(),
     ): List<E> = inTransaction(txStartedAt) { context ->
         entityRepos.repoFor(entities.first()).add(context, entities)
+    }
+
+    suspend fun <E : UpdatableEntity> update(
+        entity: E,
+        txStartedAt: Instant = clock.instant(),
+    ): E = inTransaction(txStartedAt) {
+        entityRepos.updatableRepoFor(entity).update(it, entity)
+    }
+
+    suspend fun <E : UpdatableEntity> update(
+        entities: List<E>,
+        txStartedAt: Instant = clock.instant(),
+    ): List<E> = inTransaction(txStartedAt) { context ->
+        entityRepos.updatableRepoFor(entities.first()).update(context, entities)
     }
 
     suspend fun <E : DeletableEntity> delete(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
@@ -5,6 +5,7 @@ import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.domain.ModelEvent
 import com.razz.eva.domain.ModelId
 import kotlin.reflect.KClass
@@ -42,6 +43,11 @@ class ChangesAccumulator private constructor(
     fun <E : CreatableEntity>
     withAddedEntity(entity: E): ChangesAccumulator {
         return ChangesAccumulator(modelChanges, entityChanges + AddEntity(entity))
+    }
+
+    fun <E : UpdatableEntity>
+    withUpdatedEntity(entity: E): ChangesAccumulator {
+        return ChangesAccumulator(modelChanges, entityChanges + UpdateEntity(entity))
     }
 
     fun <E : DeletableEntity>

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityBatch.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityBatch.kt
@@ -3,6 +3,7 @@ package com.razz.eva.uow
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.repository.EntityRepos
 import com.razz.eva.repository.TransactionalContext
 import kotlin.reflect.KClass
@@ -20,6 +21,20 @@ internal sealed interface EntityBatch {
         }
 
         override fun with(entity: CreatableEntity): Add<E> {
+            @Suppress("UNCHECKED_CAST")
+            entities.add(entity as E)
+            return this
+        }
+    }
+
+    class Update<E : UpdatableEntity>(entity: E) : EntityBatch {
+        private val entities = mutableListOf(entity)
+
+        override suspend fun persist(context: TransactionalContext, repos: EntityRepos) {
+            repos.updatableRepoFor(entities.first()).update(context, entities)
+        }
+
+        override fun with(entity: CreatableEntity): Update<E> {
             @Suppress("UNCHECKED_CAST")
             entities.add(entity as E)
             return this

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityChange.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityChange.kt
@@ -3,6 +3,7 @@ package com.razz.eva.uow
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import kotlin.reflect.KClass
 
 internal sealed interface EntityChange {
@@ -15,6 +16,15 @@ internal data class AddEntity<E : CreatableEntity>(
 
     override fun persist(persisting: EntityPersisting) {
         persisting.add(entity)
+    }
+}
+
+internal data class UpdateEntity<E : UpdatableEntity>(
+    private val entity: E,
+) : EntityChange {
+
+    override fun persist(persisting: EntityPersisting) {
+        persisting.update(entity)
     }
 }
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityPersisting.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/EntityPersisting.kt
@@ -3,11 +3,14 @@ package com.razz.eva.uow
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import kotlin.reflect.KClass
 
 internal interface EntityPersisting {
 
     fun <E : CreatableEntity> add(entity: E)
+
+    fun <E : UpdatableEntity> update(entity: E)
 
     fun <E : DeletableEntity> delete(entity: E)
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/PersistingAccumulator.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/PersistingAccumulator.kt
@@ -5,6 +5,7 @@ import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.repository.EntityRepos
 import com.razz.eva.repository.ModelRepos
 import com.razz.eva.repository.TransactionalContext
@@ -39,6 +40,13 @@ internal sealed interface PersistingAccumulator : ModelPersisting, EntityPersist
             }
         }
 
+        override fun <E : UpdatableEntity> update(entity: E) {
+            changes.add { context ->
+                entityRepos.updatableRepoFor(entity).update(context, entity)
+                listOf()
+            }
+        }
+
         override fun <E : DeletableEntity> delete(entity: E) {
             changes.add { context ->
                 entityRepos.deletableRepoFor(entity).delete(context, entity)
@@ -63,6 +71,7 @@ internal sealed interface PersistingAccumulator : ModelPersisting, EntityPersist
         private val updates: MutableMap<KClass<out Model<*, *>>, ModelBatch.Update<*, *>> = mutableMapOf()
         private val inserts: MutableMap<KClass<out Model<*, *>>, ModelBatch.Add<*, *>> = mutableMapOf()
         private val entityInserts: MutableMap<KClass<out CreatableEntity>, EntityBatch.Add<*>> = mutableMapOf()
+        private val entityUpdates: MutableMap<KClass<out UpdatableEntity>, EntityBatch.Update<*>> = mutableMapOf()
         private val entityDeletes: MutableMap<KClass<out DeletableEntity>, EntityBatch.Delete<*>> = mutableMapOf()
         private val entityKeyDeletes: MutableMap<KClass<out DeletableEntity>, EntityBatch.DeleteByKey<*, *>> =
             mutableMapOf()
@@ -85,6 +94,12 @@ internal sealed interface PersistingAccumulator : ModelPersisting, EntityPersist
             }
         }
 
+        override fun <E : UpdatableEntity> update(entity: E) {
+            entityUpdates.compute(entity::class) { _, v ->
+                v?.with(entity) ?: EntityBatch.Update(entity)
+            }
+        }
+
         override fun <E : DeletableEntity> delete(entity: E) {
             entityDeletes.compute(entity::class) { _, v ->
                 v?.with(entity) ?: EntityBatch.Delete(entity)
@@ -101,7 +116,12 @@ internal sealed interface PersistingAccumulator : ModelPersisting, EntityPersist
             val modelOps = listOf(updates.values, inserts.values).flatMap {
                 it.map { b -> FlushOperation { context -> b.persist(context, modelRepos) } }
             }
-            val entityOps = listOf(entityInserts.values, entityDeletes.values, entityKeyDeletes.values).flatMap {
+            val entityOps = listOf(
+                entityInserts.values,
+                entityUpdates.values,
+                entityDeletes.values,
+                entityKeyDeletes.values,
+            ).flatMap {
                 it.map { b ->
                     FlushOperation { context ->
                         b.persist(context, entityRepos)

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
@@ -4,6 +4,7 @@ import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.domain.ModelEvent
 import com.razz.eva.domain.ModelId
 import com.razz.eva.domain.Principal
@@ -78,6 +79,11 @@ class ChangesDsl internal constructor(
 
     fun <E : CreatableEntity> add(entity: E): E {
         changes = changes.withAddedEntity(entity)
+        return entity
+    }
+
+    fun <E : UpdatableEntity> update(entity: E): E {
+        changes = changes.withUpdatedEntity(entity)
         return entity
     }
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/PeekingEntityPersisting.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/PeekingEntityPersisting.kt
@@ -3,6 +3,7 @@ package com.razz.eva.uow.verify
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.uow.EntityPersisting
 import kotlin.reflect.KClass
 
@@ -12,6 +13,11 @@ internal class PeekingEntityPersisting : EntityPersisting {
     private var currentKey: EntityKey<*>? = null
 
     override fun <E : CreatableEntity> add(entity: E) {
+        require(currentEntity == null && currentKey == null)
+        currentEntity = entity
+    }
+
+    override fun <E : UpdatableEntity> update(entity: E) {
         require(currentEntity == null && currentKey == null)
         currentEntity = entity
     }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
@@ -6,6 +6,7 @@ import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelEvent
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.uow.Changes
 import kotlin.jvm.java
 
@@ -91,8 +92,17 @@ class UowSpec<R> internal constructor(
         }
     }
 
-    inline fun <reified M : Model<*, *>> updates(noinline verify: M.() -> Unit): M {
-        return verifyUpdatedModel(verify)
+    @Suppress("UNCHECKED_CAST")
+    inline fun <reified T> updates(noinline verify: T.() -> Unit): T {
+        return when {
+            Model::class.java.isAssignableFrom(T::class.java) ->
+                verifyUpdatedModel(verify as (Model<*, *>) -> Unit) as T
+            UpdatableEntity::class.java.isAssignableFrom(T::class.java) ->
+                verifyUpdatedEntity(verify as (UpdatableEntity) -> Unit) as T
+            else -> throw IllegalArgumentException(
+                "Type parameter must be either Model or UpdatableEntity, was ${T::class}",
+            )
+        }
     }
 
     inline fun <reified M : Model<*, *>> EqualityVerifierAware.updates(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
@@ -6,6 +6,7 @@ import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelEvent
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.uow.AddEntity
 import com.razz.eva.uow.AddModel
 import com.razz.eva.uow.Changes
@@ -14,6 +15,7 @@ import com.razz.eva.uow.DeleteEntityByKey
 import com.razz.eva.uow.EntityChange
 import com.razz.eva.uow.ModelChange
 import com.razz.eva.uow.NoopModel
+import com.razz.eva.uow.UpdateEntity
 import com.razz.eva.uow.UpdateModel
 import java.util.ArrayDeque
 import java.util.Deque
@@ -109,6 +111,22 @@ open class UowSpecBase<R> private constructor(
                 peekingEntityPersisting.peek()
             }
             else -> throw IllegalStateException("Expecting [AddEntity] was [$next]")
+        }
+        @Suppress("UNCHECKED_CAST")
+        verify(entity as E)
+        return entity
+    }
+
+    @PublishedApi
+    internal fun <E : UpdatableEntity> verifyUpdatedEntity(verify: (E) -> Unit): E {
+        val entity = when (
+            val next = checkNotNull(entityChangeHistory.pollFirst()) { "Expecting [UpdateEntity] got nothing" }
+        ) {
+            is UpdateEntity<*> -> {
+                next.persist(peekingEntityPersisting)
+                peekingEntityPersisting.peek()
+            }
+            else -> throw IllegalStateException("Expecting [UpdateEntity] was [$next]")
         }
         @Suppress("UNCHECKED_CAST")
         verify(entity as E)

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/ChangesSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/ChangesSpec.kt
@@ -380,6 +380,21 @@ class ChangesSpec : BehaviorSpec({
                 restored.result shouldBe "restored"
             }
         }
+
+        When("from is called with Changes that include updated entity") {
+            val subjectId2 = UUID.randomUUID()
+            val updatedTag = Tag(subjectId2, "key", "updated-value")
+            val changes = ChangesAccumulator()
+                .withUpdatedEntity(updatedTag)
+                .withResult("with-updated-entity")
+
+            val restored = ChangesAccumulator.from(changes).withResult("restored")
+
+            Then("accumulator contains updated entity change") {
+                restored.entityChangesToPersist shouldBe listOf(UpdateEntity(updatedTag))
+                restored.result shouldBe "restored"
+            }
+        }
     }
 
     Given("Entities") {
@@ -448,6 +463,60 @@ class ChangesSpec : BehaviorSpec({
             }
         }
 
+        When("Principal calling withUpdatedEntity and then withResult") {
+            val changes = ChangesAccumulator()
+                .withUpdatedEntity(tag1)
+                .withResult("tag updated")
+
+            Then("Changes matching updated entity and result produced") {
+                changes.entityChangesToPersist shouldBe listOf(UpdateEntity(tag1))
+                changes.modelChangesToPersist shouldBe listOf()
+                changes.result shouldBe "tag updated"
+            }
+        }
+
+        When("Principal calling withUpdatedEntity twice for different entities") {
+            val changes = ChangesAccumulator()
+                .withUpdatedEntity(tag1)
+                .withUpdatedEntity(tag2)
+                .withResult("tags updated")
+
+            Then("Changes contain both entities") {
+                changes.entityChangesToPersist shouldBe listOf(UpdateEntity(tag1), UpdateEntity(tag2))
+                changes.result shouldBe "tags updated"
+            }
+        }
+
+        When("Principal calling withUpdatedEntity twice for the same entity") {
+            val changes = ChangesAccumulator()
+                .withUpdatedEntity(tag1)
+                .withUpdatedEntity(tag1)
+                .withResult("duplicate tag update")
+
+            Then("Changes contain duplicate entities (no deduplication)") {
+                changes.entityChangesToPersist shouldBe listOf(UpdateEntity(tag1), UpdateEntity(tag1))
+                changes.result shouldBe "duplicate tag update"
+            }
+        }
+
+        When("Principal calling withAddedEntity and withUpdatedEntity and withDeletedEntity") {
+            val tag3 = Tag(subjectId, "key3", "value3")
+            val changes = ChangesAccumulator()
+                .withAddedEntity(tag1)
+                .withUpdatedEntity(tag2)
+                .withDeletedEntity(tag3)
+                .withResult("all entity ops")
+
+            Then("Changes contain add, update and delete") {
+                changes.entityChangesToPersist shouldBe listOf(
+                    AddEntity(tag1),
+                    UpdateEntity(tag2),
+                    DeleteEntity(tag3),
+                )
+                changes.result shouldBe "all entity ops"
+            }
+        }
+
         When("Principal calling withAddedEntity for CreatableEntity (not DeletableEntity)") {
             val changes = ChangesAccumulator()
                 .withAddedEntity(allocation)
@@ -473,6 +542,23 @@ class ChangesSpec : BehaviorSpec({
                     changes.modelChangesToPersist shouldBe listOf(AddModel(model, listOf(modelEvent)))
                     changes.entityChangesToPersist shouldBe listOf(AddEntity(tag1))
                     changes.result shouldBe "mixed changes"
+                }
+            }
+
+            When("Principal updates both model and entity") {
+                val existingModel = existingCreatedTestModel(param1 = "existing", param2 = 1L).activate()
+                val statusEvent = TestModelStatusChanged(existingModel.id(), CREATED, ACTIVE)
+                val changes = ChangesAccumulator()
+                    .withUpdatedModel(existingModel)
+                    .withUpdatedEntity(tag1)
+                    .withResult("mixed updates")
+
+                Then("Changes contain both model and entity updates") {
+                    changes.modelChangesToPersist shouldBe listOf(
+                        UpdateModel(existingModel, listOf(statusEvent)),
+                    )
+                    changes.entityChangesToPersist shouldBe listOf(UpdateEntity(tag1))
+                    changes.result shouldBe "mixed updates"
                 }
             }
         }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkDemoSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkDemoSpec.kt
@@ -73,6 +73,9 @@ class UnitOfWorkDemoSpec : UowBehaviorSpec({
                     addsEq(Tag.tag(newDepId.id, "transfer-${zoomerId.id}", "from-${oldDepId.id}"))
                     updatesEq(boomer.changeDepartment(newDep))
                     addsEq(Tag.tag(newDepId.id, "transfer-${boomerId.id}", "from-${oldDepId.id}"))
+                    updates<Tag> {
+                        this shouldBe Tag.tag(newDepId.id, "last-transfer", "batch-2")
+                    }
                     updatesEq(newDep.addEmployee(zoomer).addEmployee(boomer))
                     updatesEq(oldDep.removeEmployee(boomer).removeEmployee(zoomer))
                     deletesEq(Tag.tag(oldDepId.id, "full-staff", "true"))
@@ -105,6 +108,11 @@ class UnitOfWorkDemoSpec : UowBehaviorSpec({
                         subjectId shouldBe newDepId.id
                         name shouldBe "transfer-${boomerId.id}"
                         value shouldBe "from-${oldDepId.id}"
+                    }
+                    updates<Tag> {
+                        subjectId shouldBe newDepId.id
+                        name shouldBe "last-transfer"
+                        value shouldBe "batch-2"
                     }
                     updates<OwnedDepartment> {
                         headcount shouldBe 3

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -272,7 +272,8 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
         }
 
         And("Ad hoc factory with mixed model and entity changes") {
-            val tag = Tag.environmentTag(departmentId.id, "production")
+            val tagToAdd = Tag.environmentTag(departmentId.id, "production")
+            val tagToUpdate = Tag.priorityTag(departmentId.id, 5)
             val tagToDelete = Tag.tag(departmentId.id, "deprecated", "true")
 
             val factory = { exCtx: ExecutionContext ->
@@ -282,7 +283,8 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         params: DummyUow.Params,
                     ) = changes {
                         val addedDepartment = add(department)
-                        add(tag)
+                        add(tagToAdd)
+                        update(tagToUpdate)
                         delete(tagToDelete)
                         addedDepartment
                     }
@@ -294,7 +296,8 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 val tagRepo = mockk<DeletableEntityRepository<Tag>>(relaxed = true)
 
                 coEvery { departmentRepo.add(any(), department) } returns department
-                coEvery { tagRepo.add(any(), tag) } returns tag
+                coEvery { tagRepo.add(any(), tagToAdd) } returns tagToAdd
+                coEvery { tagRepo.update(any(), tagToUpdate) } returns tagToUpdate
                 coEvery { tagRepo.delete(any(), tagToDelete) } returns true
 
                 val uowx = UnitOfWorkExecutor(
@@ -320,15 +323,15 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                     Then("Result should be the added department") {
                         result shouldBe department
                     }
-
                     And("Model repository was called") {
                         coVerify { departmentRepo.add(any(), department) }
                     }
-
                     And("Entity repository add was called") {
-                        coVerify { tagRepo.add(any(), tag) }
+                        coVerify { tagRepo.add(any(), tagToAdd) }
                     }
-
+                    And("Entity repository update was called") {
+                        coVerify { tagRepo.update(any(), tagToUpdate) }
+                    }
                     And("Entity repository delete was called") {
                         coVerify { tagRepo.delete(any(), tagToDelete) }
                     }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
@@ -25,6 +25,7 @@ import com.razz.eva.uow.Clocks.fixedUTC
 import com.razz.eva.uow.Clocks.millisUTC
 import com.razz.eva.uow.DeleteEntity
 import com.razz.eva.uow.DeleteEntityByKey
+import com.razz.eva.uow.UpdateEntity
 import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.NoopModel
 import com.razz.eva.uow.TestPrincipal
@@ -441,6 +442,58 @@ class ChangesDslSpec : FunSpec({
         changes.modelChangesToPersist shouldBe listOf()
         changes.entityChangesToPersist shouldBe listOf(DeleteEntity(tag))
         changes.result shouldBe "ENTITY DELETED"
+    }
+
+    test("Should return properly built RealisedChanges when entity added, updated and deleted") {
+        val departmentId = randomDepartmentId()
+        val tag1 = Tag.environmentTag(departmentId.id, "staging")
+        val tag2 = Tag.priorityTag(departmentId.id, 5)
+        val tag3 = Tag.tag(departmentId.id, "region", "eu-west")
+
+        val uow = object : DummyUow<String>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                add(tag1)
+                update(tag2)
+                delete(tag3)
+                "ALL ENTITY OPS"
+            }
+        }
+        val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
+
+        changes.modelChangesToPersist shouldBe listOf()
+        changes.entityChangesToPersist shouldBe listOf(
+            AddEntity(tag1),
+            UpdateEntity(tag2),
+            DeleteEntity(tag3),
+        )
+        changes.result shouldBe "ALL ENTITY OPS"
+    }
+
+    test("Should merge entity update changes from sub-uow") {
+        val departmentId = randomDepartmentId()
+        val tag1 = Tag.environmentTag(departmentId.id, "production")
+        val tag2 = Tag.priorityTag(departmentId.id, 5)
+
+        val innerUow = { ctx: ExecutionContext ->
+            object : DummyUow<String>(ctx) {
+                override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                    update(tag2)
+                    "inner result"
+                }
+            }
+        }
+        val uow = object : DummyUow<String>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                update(tag1)
+                execute(innerUow, TestPrincipal) { Params }
+                "MERGED ENTITY UPDATES"
+            }
+        }
+        val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
+
+        changes.modelChangesToPersist shouldBe listOf()
+        changes.entityChangesToPersist shouldBe listOf(UpdateEntity(tag1), UpdateEntity(tag2))
+        changes.result shouldBe "MERGED ENTITY UPDATES"
     }
 
     test("Should return properly built RealisedChanges when model added and entity added") {

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
@@ -42,9 +42,11 @@ import com.razz.eva.uow.ExecutionStep
 import com.razz.eva.uow.ExecutionStep.EntitiesAdded
 import com.razz.eva.uow.ExecutionStep.EntitiesDeleted
 import com.razz.eva.uow.ExecutionStep.EntitiesDeletedByKey
+import com.razz.eva.uow.ExecutionStep.EntitiesUpdated
 import com.razz.eva.uow.ExecutionStep.EntityAdded
 import com.razz.eva.uow.ExecutionStep.EntityDeleted
 import com.razz.eva.uow.ExecutionStep.EntityDeletedByKey
+import com.razz.eva.uow.ExecutionStep.EntityUpdated
 import com.razz.eva.uow.ExecutionStep.ModelAdded
 import com.razz.eva.uow.ExecutionStep.ModelUpdated
 import com.razz.eva.uow.ExecutionStep.ModelsAdded
@@ -55,6 +57,7 @@ import com.razz.eva.uow.ExecutionStep.UowEventAdded
 import com.razz.eva.uow.ExecutionStep.UowEventPublished
 import com.razz.eva.uow.NoopModel
 import com.razz.eva.uow.Persisting
+import com.razz.eva.uow.UpdateEntity
 import com.razz.eva.uow.SpyCreatableEntityRepo
 import com.razz.eva.uow.SpyKeyDeletableEntityRepo
 import com.razz.eva.uow.SpyModelRepo
@@ -138,6 +141,7 @@ class PersistingSpec : BehaviorSpec({
 
     val tag1 = Tag.environmentTag(departmentId1.id, "production")
     val tag2 = Tag.priorityTag(departmentId2.id, 1)
+    val tagToUpdate = Tag.environmentTag(departmentId2.id, "staging")
     val tagToDelete = Tag.tag(departmentId3.id, "deprecated", "true")
 
     val rationAllocation1 = RationAllocation.allocation(bossId1, BUBALEH, java.time.LocalDate.now(), 3)
@@ -217,6 +221,7 @@ class PersistingSpec : BehaviorSpec({
                     entityChanges = listOf(
                         AddEntity(tag1),
                         AddEntity(tag2),
+                        UpdateEntity(tagToUpdate),
                         AddEntity(rationAllocation1),
                         AddEntity(rationAllocation2),
                         DeleteEntity(tagToDelete),
@@ -237,7 +242,7 @@ class PersistingSpec : BehaviorSpec({
                         " with context created from configured clock",
                 ) {
                     history should {
-                        it.size shouldBe 10
+                        it.size shouldBe 11
                         it[0] shouldBe TransactionStarted(REQUIRE_NEW)
                         it[1] shouldBe ModelsUpdated(transactionalContext(now), listOf(boss1, boss2))
                         it[2] shouldBe ModelsUpdated(transactionalContext(now), listOf(department3))
@@ -247,8 +252,9 @@ class PersistingSpec : BehaviorSpec({
                             transactionalContext(now),
                             listOf(rationAllocation1, rationAllocation2),
                         )
-                        it[6] shouldBe EntitiesDeleted(transactionalContext(now), listOf(tagToDelete))
-                        it[7] should { eh ->
+                        it[6] shouldBe EntitiesUpdated(transactionalContext(now), listOf(tagToUpdate))
+                        it[7] shouldBe EntitiesDeleted(transactionalContext(now), listOf(tagToDelete))
+                        it[8] should { eh ->
                             eh.shouldBeTypeOf<UowEventAdded>()
                             eh.uowEvent.occurredAt shouldBe now
                             eh.uowEvent.uowName shouldBe UowName("Hoba")
@@ -273,8 +279,8 @@ class PersistingSpec : BehaviorSpec({
                                 vals[4] shouldBe DepartmentChanged(bossId2, oldDepId, departmentId2)
                             }
                         }
-                        it[8] shouldBe TransactionFinished(REQUIRE_NEW)
-                        it[9] should { eh ->
+                        it[9] shouldBe TransactionFinished(REQUIRE_NEW)
+                        it[10] should { eh ->
                             eh.shouldBeTypeOf<UowEventPublished>()
                             eh.uowEvent.occurredAt shouldBe now
                             eh.uowEvent.uowName shouldBe UowName("Hoba")
@@ -315,7 +321,7 @@ class PersistingSpec : BehaviorSpec({
                         " with context created from configured clock",
                 ) {
                     history should {
-                        it.size shouldBe 14
+                        it.size shouldBe 15
                         it[0] shouldBe TransactionStarted(REQUIRE_NEW)
                         it[1] shouldBe ModelAdded(transactionalContext(now), department1)
                         it[2] shouldBe ModelUpdated(transactionalContext(now), boss1)
@@ -324,10 +330,11 @@ class PersistingSpec : BehaviorSpec({
                         it[5] shouldBe ModelUpdated(transactionalContext(now), boss2)
                         it[6] shouldBe EntityAdded(transactionalContext(now), tag1)
                         it[7] shouldBe EntityAdded(transactionalContext(now), tag2)
-                        it[8] shouldBe EntityAdded(transactionalContext(now), rationAllocation1)
-                        it[9] shouldBe EntityAdded(transactionalContext(now), rationAllocation2)
-                        it[10] shouldBe EntityDeleted(transactionalContext(now), tagToDelete)
-                        it[11] should { eh ->
+                        it[8] shouldBe EntityUpdated(transactionalContext(now), tagToUpdate)
+                        it[9] shouldBe EntityAdded(transactionalContext(now), rationAllocation1)
+                        it[10] shouldBe EntityAdded(transactionalContext(now), rationAllocation2)
+                        it[11] shouldBe EntityDeleted(transactionalContext(now), tagToDelete)
+                        it[12] should { eh ->
                             eh.shouldBeTypeOf<UowEventAdded>()
                             eh.uowEvent.occurredAt shouldBe now
                             eh.uowEvent.uowName shouldBe UowName("Hoba")
@@ -352,8 +359,8 @@ class PersistingSpec : BehaviorSpec({
                                 vals[4] shouldBe DepartmentChanged(bossId2, oldDepId, departmentId2)
                             }
                         }
-                        it[12] shouldBe TransactionFinished(REQUIRE_NEW)
-                        it[13] should { eh ->
+                        it[13] shouldBe TransactionFinished(REQUIRE_NEW)
+                        it[14] should { eh ->
                             eh.shouldBeTypeOf<UowEventPublished>()
                             eh.uowEvent.occurredAt shouldBe now
                             eh.uowEvent.uowName shouldBe UowName("Hoba")

--- a/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/ExecutionStep.kt
+++ b/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/ExecutionStep.kt
@@ -5,6 +5,7 @@ import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.events.UowEvent
 import com.razz.eva.persistence.ConnectionMode
 import com.razz.eva.repository.TransactionalContext
@@ -41,6 +42,16 @@ sealed class ExecutionStep {
     ) : ExecutionStep()
 
     data class EntitiesAdded<E : CreatableEntity>(
+        val context: TransactionalContext,
+        val entities: List<E>,
+    ) : ExecutionStep()
+
+    data class EntityUpdated<E : UpdatableEntity>(
+        val context: TransactionalContext,
+        val entity: E,
+    ) : ExecutionStep()
+
+    data class EntitiesUpdated<E : UpdatableEntity>(
         val context: TransactionalContext,
         val entities: List<E>,
     ) : ExecutionStep()

--- a/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/InternalMobilityUow.kt
+++ b/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/InternalMobilityUow.kt
@@ -46,6 +46,7 @@ class InternalMobilityUow(
             )
         }
         update(newDep)
+        update(Tag.tag(newDep.id().id, "last-transfer", "batch-${params.employees.size}"))
         for (oldDep in oldDeps.values) {
             update(oldDep)
             delete(

--- a/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/SpyEntityRepo.kt
+++ b/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/SpyEntityRepo.kt
@@ -3,16 +3,20 @@ package com.razz.eva.uow
 import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
+import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.repository.DeletableEntityRepository
 import com.razz.eva.repository.EntityRepository
 import com.razz.eva.repository.KeyDeletable
 import com.razz.eva.repository.TransactionalContext
+import com.razz.eva.repository.UpdatableEntityRepository
 import com.razz.eva.uow.ExecutionStep.EntitiesAdded
 import com.razz.eva.uow.ExecutionStep.EntitiesDeleted
 import com.razz.eva.uow.ExecutionStep.EntitiesDeletedByKey
+import com.razz.eva.uow.ExecutionStep.EntitiesUpdated
 import com.razz.eva.uow.ExecutionStep.EntityAdded
 import com.razz.eva.uow.ExecutionStep.EntityDeleted
 import com.razz.eva.uow.ExecutionStep.EntityDeletedByKey
+import com.razz.eva.uow.ExecutionStep.EntityUpdated
 
 @Suppress("INAPPLICABLE_JVM_NAME")
 class SpyKeyDeletableEntityRepo<E : DeletableEntity, K : EntityKey<E>>(
@@ -26,6 +30,16 @@ class SpyKeyDeletableEntityRepo<E : DeletableEntity, K : EntityKey<E>>(
 
     override suspend fun add(context: TransactionalContext, entities: List<E>): List<E> {
         history.add(EntitiesAdded(context, entities))
+        return entities
+    }
+
+    override suspend fun update(context: TransactionalContext, entity: E): E {
+        history.add(EntityUpdated(context, entity))
+        return entity
+    }
+
+    override suspend fun update(context: TransactionalContext, entities: List<E>): List<E> {
+        history.add(EntitiesUpdated(context, entities))
         return entities
     }
 


### PR DESCRIPTION
Insert UpdatableEntity between CreatableEntity and DeletableEntity in the domain hierarchy, giving all deletable entities update capability for free.

- UpdatableEntityRepository interface with update() methods
- JooqUpdatableEntityRepository with entityCondition() and update() impl
- JooqDeletableEntityRepository now extends JooqUpdatableEntityRepository
- Full UoW wiring: UpdateEntity change, EntityBatch.Update, composable ChangesDsl.update(entity), both PersistingAccumulator variants
- Verify DSL: updates<T> dispatches to entity or model verification
- Test coverage at all layers: ChangesAccumulator, ChangesDsl, Persisting, UnitOfWorkExecutor