### PR TITLE
Add findPage helper to JooqBaseEntityRepository

### DIFF
--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
@@ -9,7 +9,6 @@ import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Record
 import org.jooq.Select
-import org.jooq.SelectConditionStep
 import org.jooq.Table
 
 abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecord>(
@@ -67,15 +66,7 @@ abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecor
     }
 
     /**
-     * Keyset-paginated read. Mirrors [JooqBaseModelRepository.findPage] for entities.
-     *
-     * Example generated SQL when [page] is [Page.Next]:
-     * ```
-     * SELECT * FROM table
-     * WHERE <condition> AND (timestamp, id) > (X, Y)
-     * ORDER BY timestamp, id
-     * LIMIT pageSize
-     * ```
+     * Keyset-paginated read for entity repositories. See [executeFindPage] for the SQL shape.
      */
     protected suspend fun <ID : Comparable<ID>, N, S, P> findPage(
         condition: Condition,
@@ -85,19 +76,15 @@ abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecor
             @Suppress("UNCHECKED_CAST")
             fromRecord(it) as N
         },
-    ): PagedList<S, P> where S : N, P : Comparable<P> {
-        val list = allRecords(
-            dslContext.selectFrom(table)
-                .where(condition)
-                .page(page, pagingStrategy),
-        )
-        return pagingStrategy.pagedList(list, mapper, page.size)
-    }
-
-    private fun <ID : Comparable<ID>, N, S, P> SelectConditionStep<R>.page(
-        page: Page<P>,
-        pagingStrategy: PagingStrategy<ID, N, S, P, R>,
-    ) where S : N, P : Comparable<P> = pagingStrategy.select(this, page)
+    ): PagedList<S, P> where S : N, P : Comparable<P> = executeFindPage(
+        queryExecutor = queryExecutor,
+        dslContext = dslContext,
+        table = table,
+        condition = condition,
+        page = page,
+        pagingStrategy = pagingStrategy,
+        mapper = mapper,
+    )
 
     protected suspend fun findOneWhere(condition: Condition): E? {
         val select = dslContext.selectFrom(table).where(condition)

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
@@ -1,12 +1,15 @@
 package com.razz.eva.repository
 
 import com.razz.eva.domain.CreatableEntity
+import com.razz.eva.paging.Page
+import com.razz.eva.paging.PagedList
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.jooq.record.BaseEntityRecord
 import org.jooq.Condition
 import org.jooq.DSLContext
 import org.jooq.Record
 import org.jooq.Select
+import org.jooq.SelectConditionStep
 import org.jooq.Table
 
 abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecord>(
@@ -62,6 +65,39 @@ abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecor
         val select = dslContext.selectFrom(table).where(condition).limit(limit)
         return allRecords(select).map(::fromRecord)
     }
+
+    /**
+     * Keyset-paginated read. Mirrors [JooqBaseModelRepository.findPage] for entities.
+     *
+     * Example generated SQL when [page] is [Page.Next]:
+     * ```
+     * SELECT * FROM table
+     * WHERE <condition> AND (timestamp, id) > (X, Y)
+     * ORDER BY timestamp, id
+     * LIMIT pageSize
+     * ```
+     */
+    protected suspend fun <ID : Comparable<ID>, N, S, P> findPage(
+        condition: Condition,
+        page: Page<P>,
+        pagingStrategy: PagingStrategy<ID, N, S, P, R>,
+        mapper: (R) -> N = {
+            @Suppress("UNCHECKED_CAST")
+            fromRecord(it) as N
+        },
+    ): PagedList<S, P> where S : N, P : Comparable<P> {
+        val list = allRecords(
+            dslContext.selectFrom(table)
+                .where(condition)
+                .page(page, pagingStrategy),
+        )
+        return pagingStrategy.pagedList(list, mapper, page.size)
+    }
+
+    private fun <ID : Comparable<ID>, N, S, P> SelectConditionStep<R>.page(
+        page: Page<P>,
+        pagingStrategy: PagingStrategy<ID, N, S, P, R>,
+    ) where S : N, P : Comparable<P> = pagingStrategy.select(this, page)
 
     protected suspend fun findOneWhere(condition: Condition): E? {
         val select = dslContext.selectFrom(table).where(condition)

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseModelRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseModelRepository.kt
@@ -14,7 +14,6 @@ import org.jooq.DSLContext
 import org.jooq.Field
 import org.jooq.Record
 import org.jooq.Select
-import org.jooq.SelectConditionStep
 import org.jooq.SortField
 import org.jooq.Table
 import org.jooq.TableField
@@ -22,7 +21,7 @@ import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 
 abstract class JooqBaseModelRepository<ID, MID, M, ME, R>(
-    queryExecutor: QueryExecutor,
+    private val queryExecutor: QueryExecutor,
     private val dslContext: DSLContext,
     private val table: Table<R>,
     @Suppress("UNCHECKED_CAST")
@@ -140,17 +139,7 @@ abstract class JooqBaseModelRepository<ID, MID, M, ME, R>(
     ).singleOrNull()
 
     /**
-     * If page is not first, we use JOOQ 'seek' method to find position of page
-     * https://www.jooq.org/doc/latest/manual/sql-building/sql-statements/select-statement/seek-clause/
-     *
-     * Example of generated SQL query -
-     * SELECT id, timestamp, value
-     * FROM model
-     * WHERE (timestamp, id) > (X, Y)
-     * ORDER BY timestamp, id
-     * LIMIT 5
-     *
-     * (timestamp, id) > (X, Y) is equivalent to (timestamp > X) OR ((timestamp = X) AND (id > Y))
+     * Keyset-paginated read. See [executeFindPage] for the SQL shape.
      */
     protected suspend fun <N, S, P> findPage(
         condition: Condition,
@@ -160,19 +149,15 @@ abstract class JooqBaseModelRepository<ID, MID, M, ME, R>(
             @Suppress("UNCHECKED_CAST")
             fromRecord(it) as N
         },
-    ): PagedList<S, P> where S : N, P : Comparable<P> {
-        val list = allRecords(
-            dslContext.selectFrom(table)
-                .where(condition)
-                .page(page, pagingStrategy),
-        )
-        return pagingStrategy.pagedList(list, mapper, page.size)
-    }
-
-    private fun <N, S, P> SelectConditionStep<R>.page(
-        page: Page<P>,
-        pagingStrategy: PagingStrategy<ID, N, S, P, R>,
-    ) where S : N, P : Comparable<P> = pagingStrategy.select(this, page)
+    ): PagedList<S, P> where S : N, P : Comparable<P> = executeFindPage(
+        queryExecutor = queryExecutor,
+        dslContext = dslContext,
+        table = table,
+        condition = condition,
+        page = page,
+        pagingStrategy = pagingStrategy,
+        mapper = mapper,
+    )
 
     protected suspend fun findAllWhere(
         condition: Condition,

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/PagingExecution.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/PagingExecution.kt
@@ -1,0 +1,41 @@
+package com.razz.eva.repository
+
+import com.razz.eva.paging.Page
+import com.razz.eva.paging.PagedList
+import com.razz.eva.persistence.executor.QueryExecutor
+import org.jooq.Condition
+import org.jooq.DSLContext
+import org.jooq.Record
+import org.jooq.Table
+
+/**
+ * Shared body of [JooqBaseModelRepository.findPage] and [JooqBaseEntityRepository.findPage].
+ *
+ * If `page` is `Page.Next`, generates SQL of the form:
+ * ```
+ * SELECT * FROM <table>
+ * WHERE <condition> AND (<ordering>, <id>) > (<maxOrdering>, <offset>)
+ * ORDER BY <ordering>, <id>
+ * LIMIT pageSize
+ * ```
+ */
+internal suspend fun <ID, N, S, P, R> executeFindPage(
+    queryExecutor: QueryExecutor,
+    dslContext: DSLContext,
+    table: Table<R>,
+    condition: Condition,
+    page: Page<P>,
+    pagingStrategy: PagingStrategy<ID, N, S, P, R>,
+    mapper: (R) -> N,
+): PagedList<S, P> where ID : Comparable<ID>, S : N, P : Comparable<P>, R : Record {
+    val pagedSelect = pagingStrategy.select(
+        dslContext.selectFrom(table).where(condition),
+        page,
+    )
+    val records = queryExecutor.executeSelect(
+        dslContext = dslContext,
+        jooqQuery = pagedSelect,
+        table = table,
+    )
+    return pagingStrategy.pagedList(records, mapper, page.size)
+}


### PR DESCRIPTION
## Summary

`JooqBaseEntityRepository` (the base for `CreatableEntity` repos) didn't expose a paging helper, so consumers had to reach for raw `queryExecutor.executeSelect` and reimplement the seek/paging plumbing locally. This adds `findPage` mirroring the one on `JooqBaseModelRepository`, reusing the same `PagingStrategy` contract and `BasicPagedList` wiring — and extracts the shared body so the two repositories don't carry mirrored code.

## Scope

- New `PagingExecution.kt` with internal `executeFindPage(...)` carrying the seek/select/map body shared by both repositories.
- New `findPage` method on `JooqBaseEntityRepository` delegating to `executeFindPage`, with the same generics and contract as the model-repository version.
- `JooqBaseModelRepository.findPage` refactored to delegate to `executeFindPage` (was `allRecords(... .page(...))` plus a private `SelectConditionStep<R>.page` extension — both gone).
- `JooqBaseModelRepository`'s `queryExecutor` constructor parameter is now stored as a private field so it can be passed to the shared helper. Constructor signature unchanged.
- No behaviour changes to existing callers.