### PR TITLE
Clarify no-op update error in composable ChangesDsl

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
@@ -46,7 +46,12 @@ class ChangesDsl internal constructor(
         if (existing != null && model.id() in inheritedModelIds) {
             val newEvents = model.modelEvents()
             check(newEvents isSuccessorOf existing.modelEvents) {
-                "Failed to merge changes for model [${model.id().stringValue()}]"
+                if (newEvents isSameAs existing.modelEvents) {
+                    "No-op update for model [${model.id().stringValue()}]: no new events on top of the " +
+                        "existing change. Use notChanged(...) or guard update(...)."
+                } else {
+                    "Failed to merge changes for model [${model.id().stringValue()}]"
+                }
             }
             val merged = when (existing) {
                 is AddModel<*, *, *> -> AddModel(model, newEvents)
@@ -152,6 +157,19 @@ class ChangesDsl internal constructor(
     private infix fun List<ModelEvent<*>>
         .isSuccessorOf(events: List<ModelEvent<*>>): Boolean {
         if (size <= events.size) {
+            return false
+        }
+        events.forEachIndexed { i, e ->
+            if (this[i] !== e) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private infix fun List<ModelEvent<*>>
+        .isSameAs(events: List<ModelEvent<*>>): Boolean {
+        if (size != events.size) {
             return false
         }
         events.forEachIndexed { i, e ->

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
@@ -410,6 +410,30 @@ class ChangesDslSpec : FunSpec({
         exception.message shouldBe "Failed to merge changes for model [${model.id().stringValue()}]"
     }
 
+    test("Should throw no-op message when inherited model re-registered with identical events") {
+        val model = existingCreatedTestModel(randomTestModelId(), "noscope", 360, V1)
+        val innerUow0 = { ctx: ExecutionContext ->
+            object : DummyUow<CreatedTestModel>(ctx) {
+                override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                    update(model.changeParam1("123"))
+                }
+            }
+        }
+        val uow = object : DummyUow<String>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                val updated = execute(innerUow0, TestPrincipal) { Params }
+                update(updated)
+                "K P A C U B O"
+            }
+        }
+
+        val exception = shouldThrow<IllegalStateException> {
+            uow.tryPerform(TestPrincipal, DummyUow.Params)
+        }
+        exception.message shouldBe "No-op update for model [${model.id().stringValue()}]: no new events on " +
+            "top of the existing change. Use notChanged(...) or guard update(...)."
+    }
+
     test("Should return properly built RealisedChanges when entity is added") {
         val departmentId = randomDepartmentId()
         val tag = Tag.environmentTag(departmentId.id, "production")


### PR DESCRIPTION
## Summary

Composable `ChangesDsl.update` requires a re-registered model to strictly extend its event list (`isSuccessorOf`). When the model carries no new events (a no-op update of an already-registered model), the check threw the same generic `"Failed to merge changes for model [id]"` used for genuine event conflicts.

This splits the message so the no-op case is self-explaining, while keeping the conflict message byte-identical (no behaviour change -- it still throws):

- no-op: `No-op update for model [id]: no new events on top of the existing change. Use notChanged(...) or guard update(...).`
- conflict: `Failed to merge changes for model [id]` (unchanged)

Adds a private `isSameAs` helper mirroring `isSuccessorOf`, plus a spec for the no-op message. The three existing conflict throw-tests are unchanged.