### PR TITLE
Add roundtrip { p -> } DSL to build UoW results from persisted models

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,29 @@ class DebitAccountUow(
 }
 ```
 
+#### Returning persisted models with `roundtrip { }`
+
+When a UoW result is a single model or a collection of models, it is roundtripped through the database for you, so callers receive the flushed (version-bumped) instances. A data class that wraps several models is not roundtripped automatically. Use `roundtrip { p -> ... }` to build such a result: the lookup `p` resolves each model to its persisted instance by id.
+
+```kotlin
+class CheckoutUow(
+    private val cartQueries: (Cart.Id) -> Cart,
+    private val accountQueries: (Account.Id) -> Account,
+    executionContext: ExecutionContext,
+) : UnitOfWork<ServicePrincipal, Params, CheckoutUow.Result>(executionContext) {
+
+    data class Result(val cart: Cart, val account: Account)
+
+    override suspend fun tryPerform(principal: ServicePrincipal, params: Params) = changes {
+        val account = update(accountQueries(params.accountId).debit(totalAmount))
+        val cart = update(cartQueries(params.cartId).checkout(account.id()))
+        roundtrip { p -> Result(p(cart), p(account)) }
+    }
+}
+```
+
+At top-level execution the builder is rerun over the persisted set, so `Result` carries the flushed models, including ones registered by composed child UoWs. Under composition (a child's result consumed by a parent) the eagerly built in-memory value is returned, since there is no flush yet, so place `roundtrip { }` in the top-level UoW when you need persisted instances.
+
 ### Event sourcing
 
 #### Transactional outbox 

--- a/eva-test/src/main/kotlin/com/razz/eva/test/db/DatabaseContainer.kt
+++ b/eva-test/src/main/kotlin/com/razz/eva/test/db/DatabaseContainer.kt
@@ -3,8 +3,8 @@ package com.razz.eva.test.db
 import com.razz.eva.test.db.DockerImageName.PostgrePartmanImage16
 import com.zaxxer.hikari.HikariConfig
 import com.zaxxer.hikari.HikariDataSource
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.containers.PostgreSQLContainer.POSTGRESQL_PORT
+import org.testcontainers.postgresql.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer.POSTGRESQL_PORT
 import java.lang.Runtime.getRuntime
 import kotlin.math.ceil
 import org.testcontainers.utility.DockerImageName as TestcontainersDockerImageName
@@ -79,12 +79,12 @@ data class DatabaseContainer(
                     ?.withCpuCount(cpuCount)
             }.apply { start() }
 
-        val BASIC = DatabaseContainer(pgContainer)
+        val BASIC = DatabaseContainer(pgContainer as PostgreDockerContainer)
     }
 
     class PostgreDockerContainer(
         imageName: DockerImageName,
-    ) : PostgreSQLContainer<PostgreDockerContainer>(imageName.toTestcontainers()), Startable {
+    ) : PostgreSQLContainer(imageName.toTestcontainers()), Startable {
 
         val additionalUrlParams: String = constructUrlParameters("?", "&")
     }

--- a/eva-test/src/main/kotlin/com/razz/eva/test/db/DatabaseContainerHelper.kt
+++ b/eva-test/src/main/kotlin/com/razz/eva/test/db/DatabaseContainerHelper.kt
@@ -2,7 +2,7 @@ package com.razz.eva.test.db
 
 import com.razz.eva.test.db.DatabaseContainer.Companion.BASIC
 import mu.KotlinLogging
-import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.postgresql.PostgreSQLContainer
 import java.io.Closeable
 import java.sql.SQLException
 import java.time.Duration

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
@@ -17,23 +17,24 @@ abstract class Changes<R> {
     internal abstract val result: R
     internal abstract val modelChangesToPersist: List<ModelChange>
     internal abstract val entityChangesToPersist: List<EntityChange>
+    // Builder set by roundtrip { }; the executor runs it over persisted models. Any? since R is known only per call.
     internal open val resultBuilder: ((PersistedLookup) -> Any?)? get() = null
 }
 
 /**
- * Resolves a model to its persisted (DB-roundtripped) instance. Passed to `roundtrip { p -> ... }`;
- * post-flush it returns the flushed instance, under composition the in-memory one. Returns the argument
- * unchanged when the model was not part of this change set (e.g. read-only references).
+ * Resolves a model to its change-set instance by id: the flushed instance post-flush (top-level run),
+ * the in-memory one under composition. Returns the argument unchanged when its id is not in the change set.
  */
 interface PersistedLookup {
     operator fun <M : Model<*, *>> invoke(model: M): M
 }
 
-internal class PersistedById(
-    private val byId: Map<ModelId<out Comparable<*>>, Model<*, *>>,
+// One PersistedLookup over a by-id resolver: persisted map at top level, in-memory change set under composition.
+internal class ChangeSetLookup(
+    private val resolve: (ModelId<out Comparable<*>>) -> Model<*, *>?,
 ) : PersistedLookup {
     @Suppress("UNCHECKED_CAST")
-    override fun <M : Model<*, *>> invoke(model: M): M = (byId[model.id()] ?: model) as M
+    override fun <M : Model<*, *>> invoke(model: M): M = (resolve(model.id()) ?: model) as M
 }
 
 class ChangesAccumulator private constructor(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
@@ -17,6 +17,23 @@ abstract class Changes<R> {
     internal abstract val result: R
     internal abstract val modelChangesToPersist: List<ModelChange>
     internal abstract val entityChangesToPersist: List<EntityChange>
+    internal open val resultBuilder: ((PersistedLookup) -> Any?)? get() = null
+}
+
+/**
+ * Resolves a model to its persisted (DB-roundtripped) instance. Passed to `roundtrip { p -> ... }`;
+ * post-flush it returns the flushed instance, under composition the in-memory one. Returns the argument
+ * unchanged when the model was not part of this change set (e.g. read-only references).
+ */
+interface PersistedLookup {
+    operator fun <M : Model<*, *>> invoke(model: M): M
+}
+
+internal class PersistedById(
+    private val byId: Map<ModelId<out Comparable<*>>, Model<*, *>>,
+) : PersistedLookup {
+    @Suppress("UNCHECKED_CAST")
+    override fun <M : Model<*, *>> invoke(model: M): M = (byId[model.id()] ?: model) as M
 }
 
 class ChangesAccumulator private constructor(
@@ -74,9 +91,12 @@ class ChangesAccumulator private constructor(
 
     internal fun modelIds(): Set<ModelId<out Comparable<*>>> = modelChanges.keys
 
-    fun <R> withResult(result: R): Changes<R> {
+    fun <R> withResult(
+        result: R,
+        resultBuilder: ((PersistedLookup) -> Any?)? = null,
+    ): Changes<R> {
         require(modelChanges.isNotEmpty() || entityChanges.isNotEmpty()) { "No changes to persist" }
-        return RealisedChanges(result, flattenChildModels(), entityChanges)
+        return RealisedChanges(result, flattenChildModels(), entityChanges, resultBuilder)
     }
 
     @Suppress("UNCHECKED_CAST")
@@ -129,4 +149,5 @@ internal class RealisedChanges<R>(
     override val result: R,
     override val modelChangesToPersist: List<ModelChange>,
     override val entityChangesToPersist: List<EntityChange>,
+    override val resultBuilder: ((PersistedLookup) -> Any?)? = null,
 ) : Changes<R>()

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -170,6 +170,18 @@ class UnitOfWorkExecutor(
     private fun <RESULT> result(
         changes: Changes<RESULT>,
         persisted: List<Model<*, *>>,
+    ): RESULT {
+        val builder = changes.resultBuilder
+        if (builder != null) {
+            @Suppress("UNCHECKED_CAST")
+            return builder(PersistedById(persisted.associateBy { it.id() })) as RESULT
+        }
+        return roundtrippedResult(changes, persisted)
+    }
+
+    private fun <RESULT> roundtrippedResult(
+        changes: Changes<RESULT>,
+        persisted: List<Model<*, *>>,
     ) = when (val result = changes.result) {
         is Model<*, *> -> {
             // don't try to find persisted data for returned values such as `notChanged(model)`

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -171,10 +171,12 @@ class UnitOfWorkExecutor(
         changes: Changes<RESULT>,
         persisted: List<Model<*, *>>,
     ): RESULT {
+        // roundtrip { } builder rebuilds the result from persisted models; otherwise default-roundtrip the result.
         val builder = changes.resultBuilder
         if (builder != null) {
+            val byId = persisted.associateBy { it.id() }
             @Suppress("UNCHECKED_CAST")
-            return builder(PersistedById(persisted.associateBy { it.id() })) as RESULT
+            return builder(ChangeSetLookup { byId[it] }) as RESULT
         }
         return roundtrippedResult(changes, persisted)
     }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
@@ -12,6 +12,7 @@ import com.razz.eva.uow.OtelAttributes.MODEL_ID
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
 import com.razz.eva.uow.AddModel
+import com.razz.eva.uow.ChangeSetLookup
 import com.razz.eva.uow.Changes
 import com.razz.eva.uow.ChangesAccumulator
 import com.razz.eva.uow.ExecutionContext
@@ -28,19 +29,20 @@ class ChangesDsl internal constructor(
 ) {
     private var changes: ChangesAccumulator = executionContext.inheritedChanges ?: ChangesAccumulator()
     private val inheritedModelIds: MutableSet<ModelId<out Comparable<*>>> = changes.modelIds().toMutableSet()
+    // var: assigned by roundtrip { } mid-block; null means no roundtrip, so the executor default-roundtrips.
     private var resultBuilder: ((PersistedLookup) -> Any?)? = null
 
     private fun <R> withResult(result: R): Changes<R> = changes.withResult(result, resultBuilder)
 
     /**
-     * Builds the UoW result from persisted (DB-roundtripped) models. The lookup [p] returns each model's
-     * persisted instance post-flush; under composition (no flush yet) it returns the in-memory instance.
-     * Works for models registered by composed child UoWs too, since lookup is by id over the whole flushed
-     * set. The eagerly-built (in-memory) value is the seed callers see under composition.
+     * Builds the UoW result via [p], which resolves each model to its change-set instance by id. Top-level
+     * execution reruns this over the persisted (flushed) set, so the result carries DB-roundtripped models,
+     * including ones registered by composed child UoWs. The value built eagerly here (in-memory) is the seed
+     * returned under composition, where only the top-level UoW's builder is rerun.
      */
     fun <R> roundtrip(build: (p: PersistedLookup) -> R): R {
         resultBuilder = build
-        return build(InMemoryLookup(changes))
+        return build(ChangeSetLookup { changes.changeFor(it)?.model })
     }
 
     fun <MID, E, M> add(model: M): M
@@ -143,6 +145,7 @@ class ChangesDsl internal constructor(
                 changes = ChangesAccumulator.from(subChanges)
                 inheritedModelIds.addAll(changes.modelIds())
             }
+            // Under composition the caller gets this in-memory seed; the child's resultBuilder is not rerun.
             subChanges.result
         }
     }
@@ -192,10 +195,4 @@ class ChangesDsl internal constructor(
         }
         return true
     }
-}
-
-internal class InMemoryLookup(private val changes: ChangesAccumulator) : PersistedLookup {
-    @Suppress("UNCHECKED_CAST")
-    override fun <M : Model<*, *>> invoke(model: M): M =
-        (changes.changeFor(model.id())?.model ?: model) as M
 }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
@@ -17,6 +17,7 @@ import com.razz.eva.uow.ChangesAccumulator
 import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.InstantiationContext
 import com.razz.eva.uow.NoopModel
+import com.razz.eva.uow.PersistedLookup
 import com.razz.eva.uow.UpdateModel
 import com.razz.eva.uow.UowParams
 import io.opentelemetry.api.trace.Span
@@ -27,8 +28,20 @@ class ChangesDsl internal constructor(
 ) {
     private var changes: ChangesAccumulator = executionContext.inheritedChanges ?: ChangesAccumulator()
     private val inheritedModelIds: MutableSet<ModelId<out Comparable<*>>> = changes.modelIds().toMutableSet()
+    private var resultBuilder: ((PersistedLookup) -> Any?)? = null
 
-    private fun <R> withResult(result: R): Changes<R> = changes.withResult(result)
+    private fun <R> withResult(result: R): Changes<R> = changes.withResult(result, resultBuilder)
+
+    /**
+     * Builds the UoW result from persisted (DB-roundtripped) models. The lookup [p] returns each model's
+     * persisted instance post-flush; under composition (no flush yet) it returns the in-memory instance.
+     * Works for models registered by composed child UoWs too, since lookup is by id over the whole flushed
+     * set. The eagerly-built (in-memory) value is the seed callers see under composition.
+     */
+    fun <R> roundtrip(build: (p: PersistedLookup) -> R): R {
+        resultBuilder = build
+        return build(InMemoryLookup(changes))
+    }
 
     fun <MID, E, M> add(model: M): M
         where M : Model<MID, E>, E : ModelEvent<MID>, MID : ModelId<out Comparable<*>> {
@@ -179,4 +192,10 @@ class ChangesDsl internal constructor(
         }
         return true
     }
+}
+
+internal class InMemoryLookup(private val changes: ChangesAccumulator) : PersistedLookup {
+    @Suppress("UNCHECKED_CAST")
+    override fun <M : Model<*, *>> invoke(model: M): M =
+        (changes.changeFor(model.id())?.model ?: model) as M
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -394,6 +394,84 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
             }
         }
 
+        And("A composed child UoW registers the model and the result is built via roundtrip { p -> }") {
+            val persistedDepartment = OwnedDepartment(
+                id = departmentId,
+                name = "PersistedDepartment",
+                headcount = 1,
+                ration = Ration.BUBALEH,
+                boss = bossId,
+                modelState = newState(
+                    OwnedDepartmentCreated(
+                        departmentId = departmentId,
+                        name = "PersistedDepartment",
+                        headcount = 1,
+                        ration = Ration.BUBALEH,
+                        boss = bossId,
+                    ),
+                ),
+            )
+            fun uowxWith(departmentRepo: ModelRepository<DepartmentId, OwnedDepartment>): UnitOfWorkExecutor {
+                coEvery { departmentRepo.add(any(), department) } returns persistedDepartment
+                return UnitOfWorkExecutor(
+                    listOf(),
+                    Persisting(
+                        transactionManager = WithCtxConnectionTransactionManager(),
+                        modelRepos = ModelRepos(OwnedDepartment::class hasRepo departmentRepo),
+                        entityRepos = EntityRepos(),
+                        eventRepository = DummyEventRepository(),
+                        paramsSerializer = KotlinxParamsSerializer(),
+                    ),
+                    clock,
+                    OpenTelemetry.noop(),
+                )
+            }
+            val childRoundtrips = { exCtx: ExecutionContext ->
+                object : ComposableUnitOfWork<TestPrincipal, DummyUow.Params, DeptResult>(exCtx) {
+                    override suspend fun tryPerform(principal: TestPrincipal, params: DummyUow.Params) = changes {
+                        add(department)
+                        roundtrip { p -> DeptResult(p(department), "inner") }
+                    }
+                }
+            }
+
+            When("only the INNER (composed) UoW calls roundtrip { p -> }") {
+                val outer = { exCtx: ExecutionContext ->
+                    object : ComposableUnitOfWork<TestPrincipal, DummyUow.Params, DeptResult>(exCtx) {
+                        override suspend fun tryPerform(principal: TestPrincipal, params: DummyUow.Params) = changes {
+                            execute(childRoundtrips, principal) { DummyUow.Params }
+                        }
+                    }
+                }
+                val repo = mockk<ModelRepository<DepartmentId, OwnedDepartment>>(relaxed = true)
+                val result = uowxWith(repo).execute(TestPrincipal, outer) { DummyUow.Params }
+
+                Then("the inner builder is not re-run by the executor; the caller gets the in-memory seed") {
+                    result.dept.name shouldBe "KazahDepartment"
+                    result.note shouldBe "inner"
+                }
+            }
+
+            When("BOTH the inner and the outer UoW call roundtrip { p -> }") {
+                val outer = { exCtx: ExecutionContext ->
+                    object : ComposableUnitOfWork<TestPrincipal, DummyUow.Params, DeptResult>(exCtx) {
+                        override suspend fun tryPerform(principal: TestPrincipal, params: DummyUow.Params) = changes {
+                            val child = execute(childRoundtrips, principal) { DummyUow.Params }
+                            roundtrip { p -> DeptResult(p(child.dept), "outer") }
+                        }
+                    }
+                }
+                val repo = mockk<ModelRepository<DepartmentId, OwnedDepartment>>(relaxed = true)
+                val result = uowxWith(repo).execute(TestPrincipal, outer) { DummyUow.Params }
+
+                Then("the outer builder wins and resolves persisted; the inner builder does not interfere") {
+                    result.dept shouldBe persistedDepartment
+                    result.dept.name shouldBe "PersistedDepartment"
+                    result.note shouldBe "outer"
+                }
+            }
+        }
+
         And("Two ClassToUow with the same key") {
             val factories = listOf(
                 CreateDepartmentUow::class withFactory { mockk() },

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -339,6 +339,61 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
             }
         }
 
+        And("Ad hoc factory returning a data class result built via roundtrip { p -> }") {
+            val persistedDepartment = OwnedDepartment(
+                id = departmentId,
+                name = "PersistedDepartment",
+                headcount = 1,
+                ration = Ration.BUBALEH,
+                boss = bossId,
+                modelState = newState(
+                    OwnedDepartmentCreated(
+                        departmentId = departmentId,
+                        name = "PersistedDepartment",
+                        headcount = 1,
+                        ration = Ration.BUBALEH,
+                        boss = bossId,
+                    ),
+                ),
+            )
+            val factory = { exCtx: ExecutionContext ->
+                object : ComposableUnitOfWork<TestPrincipal, DummyUow.Params, DeptResult>(exCtx) {
+                    override suspend fun tryPerform(
+                        principal: TestPrincipal,
+                        params: DummyUow.Params,
+                    ) = changes {
+                        add(department)
+                        roundtrip { p -> DeptResult(p(department), "seed") }
+                    }
+                }
+            }
+
+            When("executed top-level with a repo returning a distinct persisted instance") {
+                val departmentRepo = mockk<ModelRepository<DepartmentId, OwnedDepartment>>(relaxed = true)
+                coEvery { departmentRepo.add(any(), department) } returns persistedDepartment
+                val uowx = UnitOfWorkExecutor(
+                    listOf(),
+                    Persisting(
+                        transactionManager = WithCtxConnectionTransactionManager(),
+                        modelRepos = ModelRepos(OwnedDepartment::class hasRepo departmentRepo),
+                        entityRepos = EntityRepos(),
+                        eventRepository = DummyEventRepository(),
+                        paramsSerializer = KotlinxParamsSerializer(),
+                    ),
+                    clock,
+                    OpenTelemetry.noop(),
+                )
+
+                val result = uowx.execute(TestPrincipal, factory) { DummyUow.Params }
+
+                Then("the transform folds the persisted instance, not the in-memory seed") {
+                    result.dept shouldBe persistedDepartment
+                    result.dept.name shouldBe "PersistedDepartment"
+                    result.note shouldBe "seed"
+                }
+            }
+        }
+
         And("Two ClassToUow with the same key") {
             val factories = listOf(
                 CreateDepartmentUow::class withFactory { mockk() },
@@ -675,3 +730,5 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
         }
     }
 })
+
+private data class DeptResult(val dept: OwnedDepartment, val note: String)

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
@@ -28,11 +28,13 @@ import com.razz.eva.uow.DeleteEntityByKey
 import com.razz.eva.uow.UpdateEntity
 import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.NoopModel
+import com.razz.eva.uow.PersistedLookup
 import com.razz.eva.uow.TestPrincipal
 import com.razz.eva.uow.UpdateModel
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.opentelemetry.api.OpenTelemetry
@@ -75,6 +77,49 @@ class ChangesDslSpec : FunSpec({
             NoopModel(model2),
         )
         changes.result shouldBe "K P A C U B O"
+    }
+
+    test("roundtrip { p -> } seeds with the in-memory result and exposes a builder over persisted models") {
+        val model0 = createdTestModel("MLG", 420).activate()
+
+        val uow = object : DummyUow<RoundtripResult>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                add(model0)
+                roundtrip { p -> RoundtripResult(p(model0), "label") }
+            }
+        }
+        val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
+
+        // seed is the in-memory model (composition / pre-flush view)
+        changes.result shouldBe RoundtripResult(model0, "label")
+
+        // the builder rebuilds from whatever the persisted lookup resolves
+        val persisted = existingCreatedTestModel(model0.id(), "PERSISTED", 999, V1).activate()
+        val lookup = object : PersistedLookup {
+            @Suppress("UNCHECKED_CAST")
+            override fun <M : com.razz.eva.domain.Model<*, *>> invoke(model: M): M =
+                (if (model.id() == model0.id()) persisted else model) as M
+        }
+        changes.resultBuilder.shouldNotBeNull().invoke(lookup) shouldBe RoundtripResult(persisted, "label")
+    }
+
+    test("roundtrip { p -> } leaves models absent from the change set untouched") {
+        val added = createdTestModel("MLG", 420).activate()
+        val unrelated = existingCreatedTestModel(randomTestModelId(), "other", 1, V1)
+
+        val uow = object : DummyUow<RoundtripResult>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                add(added)
+                roundtrip { p -> RoundtripResult(p(unrelated), "label") }
+            }
+        }
+        val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
+
+        // unrelated was never added; an empty persisted lookup returns it unchanged
+        val emptyLookup = object : PersistedLookup {
+            override fun <M : com.razz.eva.domain.Model<*, *>> invoke(model: M): M = model
+        }
+        changes.resultBuilder.shouldNotBeNull().invoke(emptyLookup) shouldBe RoundtripResult(unrelated, "label")
     }
 
     test("Should throw exception when new model updated without inherited change") {
@@ -938,3 +983,5 @@ class ChangesDslSpec : FunSpec({
         exception.message shouldBe "Change for a given model [${model.id().stringValue()}] was already registered"
     }
 })
+
+private data class RoundtripResult(val model: com.razz.eva.domain.TestModel, val label: String)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,7 +27,7 @@ micrometer-bom = { module = "io.micrometer:micrometer-bom", version = "1.14.1" }
 opentelemetry-instrumentation-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom", version = "2.28.1" }
 opentelemetry-instrumentation-alpha-bom = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-bom-alpha", version = "2.28.1-alpha" }
 
-testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "1.21.4" }
+testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version = "2.0.5" }
 kotest-bom = { module = "io.kotest:kotest-bom", version = "6.1.11" }
 
 # managed by BOMs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,7 @@ kotest-runner = { module = "io.kotest:kotest-runner-junit5-jvm" }
 kotest-assertions-json = { module = "io.kotest:kotest-assertions-json-jvm" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core-jvm" }
 
-testcontainers-postgres = { module = "org.testcontainers:postgresql" }
+testcontainers-postgres = { module = "org.testcontainers:testcontainers-postgresql" }
 
 jooq = { module = "org.jooq:jooq" }
 jooq-postgres = { module = "org.jooq:jooq-postgres-extensions" }


### PR DESCRIPTION
When a UoW returns a wrapper/data-class result (e.g. `Result(invoice, document)`), the executor only roundtrips bare `Model` or `Collection<Model>` results into their persisted (DB-flushed, version-bumped) instances — a data-class result falls through `result()`'s `else` branch and is returned with pre-persist, in-memory models. There is no way to get the persisted instances into a composite result short of re-reading by id at the call site.

This adds a `roundtrip { p -> ... }` terminal builder to the composable `ChangesDsl`:

```kotlin
changes {
    add(invoice)
    update(document.attachInvoiceId(invoice.id()))
    roundtrip { p -> Result(p(invoice), p(document)) }   // p resolves persisted-or-self
}
```

- `p: PersistedLookup` resolves each model to its persisted instance post-flush, by id over the whole flushed set — so it works for models registered by **composed child UoWs**, not just ones the UoW added/updated itself.
- The eagerly-built value (in-memory lookup) is the seed returned **under composition** (where no flush happens), so a composed child still yields in-memory instances for threading; the same UoW run top-level yields persisted instances. The persisted-vs-in-memory distinction becomes a property of the execution path, not the result shape.
- Models absent from the change set are returned unchanged.

Tests: `ChangesDslSpec` (seed + builder over persisted lookup, and absent-model passthrough) and an end-to-end `UnitOfWorkExecutorSpec` proving the executor folds the distinct repo-returned instance.