### PR TITLE
Add opt-in staleAfter re-read to ModelParam

### DIFF
--- a/eva-domain/src/main/kotlin/com/razz/eva/domain/Model.kt
+++ b/eva-domain/src/main/kotlin/com/razz/eva/domain/Model.kt
@@ -24,4 +24,8 @@ abstract class Model<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         @Suppress("UNCHECKED_CAST")
         return proto as? T
     }
+
+    // Nanoseconds this model has been held in memory since it was hydrated from storage, or null if it was
+    // never persisted (a brand-new model). Monotonic and JVM-local; lets a holder decide if its reference is stale.
+    internal fun heldNanos(): Long? = modelState.readMark?.let { System.nanoTime() - it }
 }

--- a/eva-domain/src/main/kotlin/com/razz/eva/domain/ModelState.kt
+++ b/eva-domain/src/main/kotlin/com/razz/eva/domain/ModelState.kt
@@ -6,6 +6,9 @@ import com.razz.eva.domain.Version.Companion.V0
 sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
     protected val version: Version,
     events: Collection<E>,
+    // Monotonic System.nanoTime() taken when the model was hydrated from storage; null for never-persisted models.
+    // Measures the in-process age of a held model between read and use; JVM-local and never serialized.
+    internal val readMark: Long?,
 ) : ModelStateMixin<ID, E> {
 
     protected val occurredEvents = events.toList()
@@ -31,7 +34,7 @@ sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
     class PersistentState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> private constructor(
         version: Version,
         internal val proto: Any?,
-    ) : ModelState<ID, E>(version, listOf()) {
+    ) : ModelState<ID, E>(version, listOf(), System.nanoTime()) {
 
         init {
             check(version() != V0 && occurredEvents.isEmpty()) {
@@ -40,7 +43,7 @@ sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         }
 
         override fun raiseEvents(newEvents: List<E>): DirtyState<ID, E> {
-            return dirtyState(version, newEvents, proto)
+            return dirtyState(version, newEvents, proto, readMark)
         }
 
         companion object {
@@ -57,7 +60,8 @@ sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         version: Version,
         events: Collection<E>,
         internal val proto: Any?,
-    ) : ModelState<ID, E>(version, events) {
+        readMark: Long?,
+    ) : ModelState<ID, E>(version, events, readMark) {
 
         init {
             check(occurredEvents.isNotEmpty()) {
@@ -66,7 +70,7 @@ sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
         }
 
         override fun raiseEvents(newEvents: List<E>): DirtyState<ID, E> {
-            return dirtyState(version, occurredEvents + newEvents, proto)
+            return dirtyState(version, occurredEvents + newEvents, proto, readMark)
         }
 
         companion object {
@@ -74,15 +78,16 @@ sealed class ModelState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>>(
                 version: Version,
                 events: Collection<E>,
                 proto: Any?,
+                readMark: Long?,
             ): DirtyState<ID, E> {
-                return DirtyState(version, events, proto)
+                return DirtyState(version, events, proto, readMark)
             }
         }
     }
 
     class NewState<ID : ModelId<out Comparable<*>>, E : ModelEvent<ID>> private constructor(
         events: Collection<E>,
-    ) : ModelState<ID, E>(V0, events) {
+    ) : ModelState<ID, E>(V0, events, null) {
 
         init {
             check(version() == V0 && occurredEvents.isNotEmpty()) {

--- a/eva-domain/src/test/kotlin/com/razz/eva/domain/ModelStateSpec.kt
+++ b/eva-domain/src/test/kotlin/com/razz/eva/domain/ModelStateSpec.kt
@@ -14,6 +14,7 @@ import com.razz.eva.domain.Version.Companion.V1
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldBeEqualIgnoringCase
 import io.kotest.matchers.types.beInstanceOf
 
@@ -56,6 +57,14 @@ class ModelStateSpec : BehaviorSpec({
                 }
             }
         }
+
+        When("Get read mark") {
+            val readMark = newState.readMark
+
+            Then("Read mark is absent for a never-persisted model") {
+                readMark shouldBe null
+            }
+        }
     }
 
     Given("Dirty model state") {
@@ -66,6 +75,7 @@ class ModelStateSpec : BehaviorSpec({
             version = V1,
             events = listOf(firstTestModelEvent, secondTestModelEvent),
             proto = null,
+            readMark = null,
         )
 
         When("Get model events") {
@@ -73,6 +83,14 @@ class ModelStateSpec : BehaviorSpec({
 
             Then("Two test events are present") {
                 events shouldBe listOf(firstTestModelEvent, secondTestModelEvent)
+            }
+        }
+
+        When("Get read mark") {
+            val readMark = dirtyState.readMark
+
+            Then("Read mark reflects the value it was built with") {
+                readMark shouldBe null
             }
         }
     }
@@ -99,6 +117,14 @@ class ModelStateSpec : BehaviorSpec({
             }
         }
 
+        When("Get read mark") {
+            val readMark = persistentState.readMark
+
+            Then("Read mark is captured at construction") {
+                readMark shouldNotBe null
+            }
+        }
+
         And("New events") {
             val event1 = TestModelEvent1(randomTestModelId())
             val event2 = TestModelEvent1(randomTestModelId())
@@ -111,6 +137,13 @@ class ModelStateSpec : BehaviorSpec({
                 }
                 And("Model state is dirty") {
                     dirtyState shouldBe beInstanceOf<DirtyState<TestModelId, TestModelEvent>>()
+                }
+                And("Read mark is carried over from the persistent state") {
+                    dirtyState.readMark shouldBe persistentState.readMark
+                }
+                And("Raising further events keeps the same read mark") {
+                    dirtyState.raiseEvent(TestModelEvent2(randomTestModelId())).readMark shouldBe
+                        persistentState.readMark
                 }
             }
         }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
@@ -4,6 +4,7 @@ import com.razz.eva.domain.Identifiable
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelId
 import com.razz.eva.uow.ModelParam.Serializer
+import java.time.Duration
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -14,22 +15,30 @@ import kotlinx.serialization.encoding.Encoder
 class ModelParam<MID : ModelId<out Comparable<*>>, M : Model<MID, *>> private constructor(
     private var model: M?,
     private val id: MID,
+    private val staleAfter: Duration?,
     private val modelQueries: suspend (MID) -> M,
 ) : Identifiable<MID> {
 
-    private constructor(model: M, modelQueries: suspend (MID) -> M) : this(model, model.id(), modelQueries)
-    private constructor(id: MID, modelQueries: suspend (MID) -> M) : this(null, id, modelQueries)
+    private constructor(model: M, staleAfter: Duration?, modelQueries: suspend (MID) -> M) :
+        this(model, model.id(), staleAfter, modelQueries)
+    private constructor(id: MID, modelQueries: suspend (MID) -> M) : this(null, id, null, modelQueries)
 
     override fun id(): MID = id
     suspend fun model(): M {
         val currentModel = model
-        return if (currentModel == null) {
+        return if (currentModel == null || isStale(currentModel)) {
             val newModel = modelQueries(id)
             model = newModel
             newModel
         } else {
             currentModel
         }
+    }
+
+    private fun isStale(heldModel: M): Boolean {
+        val staleAfterNanos = staleAfter?.toNanos() ?: return false
+        val heldNanos = heldModel.heldNanos() ?: return false
+        return heldNanos > staleAfterNanos
     }
 
     class Serializer<MID : ModelId<out Comparable<*>>>(
@@ -48,18 +57,25 @@ class ModelParam<MID : ModelId<out Comparable<*>>, M : Model<MID, *>> private co
             model: M,
             modelQueries: suspend (MID) -> M,
         ): ModelParam<MID, M> {
-            val modelParam = if (attempt == 0) {
-                ModelParam(model, modelQueries)
+            return modelParam(model, null, modelQueries)
+        }
+
+        fun <MID : ModelId<out Comparable<*>>, M : Model<MID, *>> InstantiationContext.modelParam(
+            model: M,
+            staleAfter: Duration?,
+            modelQueries: suspend (MID) -> M,
+        ): ModelParam<MID, M> {
+            return if (attempt == 0) {
+                ModelParam(model, staleAfter, modelQueries)
             } else {
                 ModelParam(model.id(), modelQueries)
             }
-            return modelParam
         }
 
         fun <MID : ModelId<out Comparable<*>>, M : Model<MID, *>> InstantiationContext.Internal.constantModelParam(
             model: M,
         ): ModelParam<MID, M> {
-            return ModelParam(model) { model }
+            return ModelParam(model, null) { model }
         }
 
         fun <MID : ModelId<out Comparable<*>>, M : Model<MID, *>> idModelParam(

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
@@ -4,6 +4,7 @@ import com.razz.eva.domain.TestModel
 import com.razz.eva.uow.ModelParam.Factory.modelParam
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import java.time.Duration
 
 class ModelParamSpec : FunSpec({
 
@@ -35,4 +36,39 @@ class ModelParamSpec : FunSpec({
         modelParam.model().id() shouldBe oldModel.id()
         queryCount shouldBe 1
     }
+
+    test("Model param re-queries when the held model is older than staleAfter") {
+        val heldModel = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337)
+        var queryCount = 0
+        val modelParam = InstantiationContext(0).modelParam(heldModel, Duration.ofMillis(1)) { id ->
+            queryCount++
+            id shouldBe heldModel.id()
+            TestModel.existingCreatedTestModel(id = heldModel.id(), param1 = "pek", param2 = 100500)
+        }
+        Thread.sleep(STALENESS_SLEEP_MILLIS)
+        val requeried = modelParam.model()
+        requeried.param1 shouldBe "pek"
+        requeried.param2 shouldBe 100500
+        queryCount shouldBe 1
+    }
+
+    test("Model param keeps the held model when it is younger than staleAfter") {
+        val heldModel = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337)
+        val modelParam = InstantiationContext(0).modelParam(heldModel, Duration.ofHours(1)) {
+            error("not used")
+        }
+        modelParam.model().param1 shouldBe heldModel.param1
+    }
+
+    test("Model param never re-queries when staleAfter is null even if the held model is old") {
+        val heldModel = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337)
+        val modelParam = InstantiationContext(0).modelParam(heldModel) { error("not used") }
+        Thread.sleep(STALENESS_SLEEP_MILLIS)
+        modelParam.model().param1 shouldBe heldModel.param1
+    }
 })
+
+// Real time must elapse here, not coroutine time: the staleness check reads System.nanoTime(), which a
+// virtual-time test dispatcher (delay) would not advance. Thread.sleep burns real wall-clock regardless of
+// dispatcher. 20ms comfortably exceeds the 1ms staleAfter thresholds above, so the checks stay deterministic.
+private const val STALENESS_SLEEP_MILLIS = 20L


### PR DESCRIPTION
A few hot aggregates (one row, many concurrent writers) produce a high volume of optimistic-lock retries. The dominant factor is how long a model is held between read and write: a caller reads version X, does slow work (an external call, or sequential processing of a page of entities), then the UoW updates `WHERE version = X` and loses the race. Eva's retry already proves the fix, since it re-reads the model fresh on attempt > 0 and almost always succeeds.

`PersistentState` now captures a monotonic `System.nanoTime()` at hydration, carried into `DirtyState` (mutation does not reset it) and exposed as `Model.heldNanos()`. `ModelParam` gains an opt-in `staleAfter: Duration?` overload: when the held model has been in memory longer than the threshold, `model()` re-reads by id (the same path retries use) instead of persisting against a stale version.

Opt-in and default off, so the uncontended path and existing call sites are unchanged. The mark is monotonic (immune to clock adjustments and to the frozen per-UoW clock) and JVM-local; it is never serialised, as `ModelParam` persists the id only.
