### PR TITLE
Add uow.persistence_exception counter metric

### DIFF
--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
@@ -14,11 +14,15 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
         val constraintName: String?
     }
 
+    sealed interface TableAware {
+        val tableName: String
+    }
+
     open class UniqueModelRecordViolationException(
         val modelId: ModelId<*>,
-        val tableName: String,
+        override val tableName: String,
         override val constraintName: String?,
-    ) : ConstraintViolation, ModelAware, PersistenceException(
+    ) : ConstraintViolation, ModelAware, TableAware, PersistenceException(
         "Uniqueness of [$tableName]:[${modelId.stringValue()}]" +
             " violated ${constraintName?.let { ": [$it]" }}",
     ) {
@@ -28,9 +32,9 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
 
     open class ModelRecordConstraintViolationException(
         val modelId: ModelId<*>,
-        val tableName: String,
+        override val tableName: String,
         override val constraintName: String?,
-    ) : ConstraintViolation, ModelAware, PersistenceException(
+    ) : ConstraintViolation, ModelAware, TableAware, PersistenceException(
         "Constraint for [$tableName]:[${modelId.stringValue()}]" +
             " violated ${constraintName?.let { ": [$it]" }}",
     ) {
@@ -50,8 +54,8 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
 
     class StaleRecordException(
         override val modelIds: Set<ModelId<*>>,
-        val tableName: String,
-    ) : ModelAware, PersistenceException(
+        override val tableName: String,
+    ) : ModelAware, TableAware, PersistenceException(
         $$"Rows for $${
             modelIds.joinToString(
                 prefix = "[",

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/OtelAttributes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/OtelAttributes.kt
@@ -11,5 +11,9 @@ internal object OtelAttributes {
     const val PRINCIPAL_ID = "principal.id"
     const val MODEL_NAME = "model.name"
     const val EVENT_NAME = "event.name"
+    const val EXCEPTION = "exception"
+    const val TABLE = "table"
+    const val ATTEMPT = "attempt"
+    const val WILL_RETRY = "will_retry"
     val MODEL_ID = AttributeKey.stringArrayKey("model.id")
 }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -7,15 +7,19 @@ import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.razz.eva.tracing.getEvaMeter
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
+import com.razz.eva.uow.OtelAttributes.ATTEMPT
 import com.razz.eva.uow.OtelAttributes.EVENT_NAME
+import com.razz.eva.uow.OtelAttributes.EXCEPTION
 import com.razz.eva.uow.OtelAttributes.MODEL_ID
 import com.razz.eva.uow.OtelAttributes.MODEL_NAME
 import com.razz.eva.uow.OtelAttributes.PRINCIPAL_ID
 import com.razz.eva.uow.OtelAttributes.SPAN_PERFORM
 import com.razz.eva.uow.OtelAttributes.SPAN_PERSIST
+import com.razz.eva.uow.OtelAttributes.TABLE
 import com.razz.eva.uow.OtelAttributes.UOW_ID
 import com.razz.eva.uow.OtelAttributes.UOW_NAME
 import com.razz.eva.uow.OtelAttributes.UOW_OPERATION
+import com.razz.eva.uow.OtelAttributes.WILL_RETRY
 import com.razz.eva.uow.UnitOfWorkExecutor.ClassToUow
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
@@ -141,7 +145,9 @@ class UnitOfWorkExecutor(
                         ),
                     )
                     val config = uow.configuration()
-                    if (config.retry.shouldRetry(currentAttempt, ex)) {
+                    val willRetry = config.retry.shouldRetry(currentAttempt, ex)
+                    incrementPersistenceExceptionMetric(ex, name, currentAttempt, willRetry)
+                    if (willRetry) {
                         currentAttempt += 1
                         logger.warn(ex) {
                             "Retrying UnitOfWork: ${uow.name()}. Attempt: $currentAttempt"
@@ -272,6 +278,35 @@ class UnitOfWorkExecutor(
     private fun eventsMetric() = openTelemetry.getEvaMeter()
         .counterBuilder("model.event")
         .setDescription("Number of model events emitted")
+        .setUnit("count")
+        .build()
+
+    private fun incrementPersistenceExceptionMetric(
+        ex: PersistenceException,
+        uowName: String,
+        attempt: Int,
+        willRetry: Boolean,
+    ) {
+        runCatching {
+            persistenceExceptionMetric().add(
+                1,
+                Attributes.of(
+                    AttributeKey.stringKey(UOW_NAME), uowName,
+                    AttributeKey.stringKey(EXCEPTION), ex::class.simpleName ?: "Unknown",
+                    AttributeKey.stringKey(TABLE), tableName(ex),
+                    AttributeKey.longKey(ATTEMPT), attempt.toLong(),
+                    AttributeKey.booleanKey(WILL_RETRY), willRetry,
+                ),
+            )
+        }
+    }
+
+    private fun tableName(ex: PersistenceException): String =
+        (ex as? PersistenceException.TableAware)?.tableName ?: "unknown"
+
+    private fun persistenceExceptionMetric() = openTelemetry.getEvaMeter()
+        .counterBuilder("uow.persistence_exception")
+        .setDescription("Number of persistence exceptions caught during UnitOfWork execution")
         .setUnit("count")
         .build()
 

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -13,6 +13,7 @@ import com.razz.eva.events.UowEvent
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
+import com.razz.eva.persistence.PersistenceException.UniqueUowEventRecordViolationException
 import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.razz.eva.persistence.WithCtxConnectionTransactionManager
 import com.razz.eva.repository.DeletableEntityRepository
@@ -22,6 +23,7 @@ import com.razz.eva.repository.ModelRepos
 import com.razz.eva.repository.ModelRepository
 import com.razz.eva.repository.hasEntityRepo
 import com.razz.eva.repository.hasRepo
+import com.razz.eva.test.tracing.OpenTelemetryTestConfiguration
 import com.razz.eva.uow.BaseUnitOfWork.Configuration
 import com.razz.eva.uow.Clocks.fixedUTC
 import com.razz.eva.uow.params.kotlinx.KotlinxParamsSerializer
@@ -38,6 +40,8 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import java.time.Duration.ofMillis
 import java.time.Instant.ofEpochMilli
 import java.util.*
@@ -806,7 +810,177 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 }
             }
         }
+
+        And("Persistence exception counter metric") {
+            val uowName = "MockOfCreateDepartmentUow"
+            val unitOfWork = mockk<CreateDepartmentUow>()
+            val rawUnitOfWork = unitOfWork as UnitOfWork<TestPrincipal, Params, OwnedDepartment>
+            val persisting = mockk<Persisting>(relaxed = true)
+            every { unitOfWork.name() } returns uowName
+            every { rawUnitOfWork.configuration() } returns
+                Configuration(StaleRecordFixedRetry(1, ofMillis(0)), supportsOutOfOrderPersisting = true)
+            coEvery {
+                rawUnitOfWork.tryPerform(TestPrincipal, eq(params))
+            } returns RealisedChanges(department, listOf(), listOf())
+            val metricReader = InMemoryMetricReader.create()
+            val uowx = UnitOfWorkExecutor(
+                persisting = persisting,
+                factories = listOf(CreateDepartmentUow::class withFactory { unitOfWork }),
+                clock = clock,
+                openTelemetry = OpenTelemetryTestConfiguration.create(metricReader = metricReader),
+            )
+
+            And("Persisting throws StaleRecordException once then succeeds") {
+                val ex = StaleRecordException(depId, "departments")
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = true,
+                    )
+                } throws ex andThen Pair(UowEvent.Id.random(), listOf(department))
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Counter records a single retried conflict at attempt 0") {
+                        metricReader.persistenceExceptionPoints() shouldBe listOf(
+                            ExcPoint(uowName, "StaleRecordException", "departments", 0L, true, 1L),
+                        )
+                    }
+                }
+            }
+
+            And("Persisting throws StaleRecordException until retries are exhausted") {
+                val ex = StaleRecordException(depId, "departments")
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = true,
+                    )
+                } throws ex
+                coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Counter records the retried conflict and the exhausted failure") {
+                        metricReader.persistenceExceptionPoints().toSet() shouldBe setOf(
+                            ExcPoint(uowName, "StaleRecordException", "departments", 0L, true, 1L),
+                            ExcPoint(uowName, "StaleRecordException", "departments", 1L, false, 1L),
+                        )
+                    }
+                }
+            }
+
+            And("Persisting succeeds on the first attempt") {
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = true,
+                    )
+                } returns Pair(UowEvent.Id.random(), listOf(department))
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Counter is not incremented") {
+                        metricReader.persistenceExceptionPoints() shouldBe listOf()
+                    }
+                }
+            }
+
+            And("Persisting throws a non-retryable UniqueModelRecordViolationException") {
+                val ex = UniqueModelRecordViolationException(depId, "DEPARTMENTS", "departments_name_idx")
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = true,
+                    )
+                } throws ex
+                coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Counter records the constraint table and a non-retried failure at attempt 0") {
+                        metricReader.persistenceExceptionPoints() shouldBe listOf(
+                            ExcPoint(uowName, "UniqueModelRecordViolationException", "DEPARTMENTS", 0L, false, 1L),
+                        )
+                    }
+                }
+            }
+
+            And("Persisting throws an exception without a table name") {
+                val ex = UniqueUowEventRecordViolationException(UUID.randomUUID(), uowName, null, "uow_events_idx")
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = true,
+                    )
+                } throws ex
+                coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Counter falls back to the unknown table") {
+                        metricReader.persistenceExceptionPoints() shouldBe listOf(
+                            ExcPoint(uowName, "UniqueUowEventRecordViolationException", "unknown", 0L, false, 1L),
+                        )
+                    }
+                }
+            }
+        }
     }
 })
+
+private data class ExcPoint(
+    val uowName: String?,
+    val exception: String?,
+    val table: String?,
+    val attempt: Long?,
+    val willRetry: Boolean?,
+    val value: Long,
+)
+
+private fun InMemoryMetricReader.persistenceExceptionPoints(): List<ExcPoint> =
+    collectAllMetrics()
+        .filter { it.name == "uow.persistence_exception" }
+        .flatMap { metric -> metric.longSumData.points }
+        .map { point ->
+            ExcPoint(
+                uowName = point.attributes.get(AttributeKey.stringKey("uow.name")),
+                exception = point.attributes.get(AttributeKey.stringKey("exception")),
+                table = point.attributes.get(AttributeKey.stringKey("table")),
+                attempt = point.attributes.get(AttributeKey.longKey("attempt")),
+                willRetry = point.attributes.get(AttributeKey.booleanKey("will_retry")),
+                value = point.value,
+            )
+        }
 
 private data class DeptResult(val dept: OwnedDepartment, val note: String)


### PR DESCRIPTION
Adds an in-code counter incremented on every `PersistenceException` caught in the UoW retry loop, complementing the existing (sampled) `persistence.exception` span event with an exact, low-cardinality, alertable signal of which UoWs/tables contend and how often they retry vs. fail.

Labels: `uow.name`, `exception` (class name), `table`, `attempt`, `will_retry`. `will_retry` is the retry-policy decision evaluated at the catch site (the conflict hasn't been retried yet), and separates conflicts that will retry from those that exhaust the budget and reach `onFailure` — which the WARN logs cannot.

Table name is read through a new `PersistenceException.TableAware` interface (mirroring `ModelAware`); the persistence executors already capture it at construction, so the UoW layer no longer re-derives it. Falls back to `unknown` for exceptions without a table. Guarded by `runCatching` so instrumentation can never affect execution. Additive, no API break.
