### PR TITLE
Add firstRecord helper for fan-out top-row queries

### DIFF
--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/AbstractJooqRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/AbstractJooqRepository.kt
@@ -270,6 +270,18 @@ abstract class AbstractJooqRepository<ID, MID, M, ME, R>(
             }
     }
 
+    /**
+     * Returns the first record of [select] or null if none.
+     *
+     * Use when a query intentionally fans out (joins, retry history, audit rows, etc.)
+     * and the caller wants the top row by an [SelectLimitStep#orderBy] criterion.
+     * Differs from [atMostOneRecord] which enforces a "≤1" invariant and throws on more than
+     * one row. A `.limit(1)` is applied internally so callers don't have to remember it.
+     */
+    protected suspend fun <R : Record> firstRecord(select: SelectLimitStep<R>): R? {
+        return allRecords(select.limit(1)).firstOrNull()
+    }
+
     protected suspend fun <R : Record> allRecords(select: Select<R>): List<R> {
         return queryExecutor.executeSelect(
             dslContext = dslContext,

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqBaseEntityRepository.kt
@@ -121,6 +121,18 @@ abstract class JooqBaseEntityRepository<E : CreatableEntity, R : BaseEntityRecor
         }
     }
 
+    /**
+     * Returns the first record of [select] or null if none.
+     *
+     * Use when a query intentionally fans out (joins, retry history, audit rows, etc.)
+     * and the caller wants the top row by an [SelectLimitStep#orderBy] criterion.
+     * Differs from [atMostOneRecord] which enforces a "≤1" invariant and throws on more than
+     * one row. A `.limit(1)` is applied internally so callers don't have to remember it.
+     */
+    protected suspend fun <R : Record> firstRecord(select: SelectLimitStep<R>): R? {
+        return allRecords(select.limit(1)).firstOrNull()
+    }
+
     protected suspend fun <R : Record> allRecords(select: Select<R>): List<R> {
         return queryExecutor.executeSelect(
             dslContext = dslContext,

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryFirstRecordSpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryFirstRecordSpec.kt
@@ -1,0 +1,50 @@
+package com.razz.eva.repository
+
+import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor
+import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.SelectExecuted
+import com.razz.eva.test.schema.tables.records.TagRecord
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.conf.ParamType.INLINED
+import org.jooq.impl.DSL
+import java.util.UUID.randomUUID
+
+class JooqBaseRepositoryFirstRecordSpec : BehaviorSpec({
+    Given("JooqBaseEntityRepository with hacked queryExecutor") {
+        val dslContext = DSL.using(POSTGRES)
+        val queryExecutor = FakeMemorizingQueryExecutor()
+
+        val repo = TagRepository(queryExecutor, dslContext)
+
+        When("Query executor returns multiple records for firstRecord") {
+            val subjectId = randomUUID()
+            queryExecutor.expectQueryFor(
+                TagRecord(subjectId, "first", "earliest"),
+                TagRecord(subjectId, "second", "later"),
+            )
+
+            val found = repo.findFirstBySubject(subjectId)
+
+            Then("firstRecord returns the first record without throwing on extras") {
+                found shouldNotBe null
+                found?.subjectId shouldBe subjectId
+                found?.name shouldBe "first"
+                found?.value shouldBe "earliest"
+            }
+
+            Then("Query executor receives a select with limit 1") {
+                val select = queryExecutor.lastExecution.shouldBeTypeOf<SelectExecuted>()
+                select.jooqQuery.getSQL(INLINED) shouldBe """
+                    select "tag"."subject_id", "tag"."name", "tag"."value"
+                    from "tag"
+                    where "tag"."subject_id" = cast('$subjectId' as uuid)
+                    order by "tag"."name" asc
+                    fetch next 1 rows only
+                """.trim().replace(Regex("\\s+"), " ")
+            }
+        }
+    }
+})

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/repository/TagRepository.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/repository/TagRepository.kt
@@ -41,6 +41,13 @@ class TagRepository(
     suspend fun findBySubjectAndName(subjectId: UUID, name: String): Tag? =
         findOneWhere(TagTable.TAG.SUBJECT_ID.eq(subjectId).and(TagTable.TAG.NAME.eq(name)))
 
+    suspend fun findFirstBySubject(subjectId: UUID): Tag? {
+        val select = dsl.selectFrom(TagTable.TAG)
+            .where(TagTable.TAG.SUBJECT_ID.eq(subjectId))
+            .orderBy(TagTable.TAG.NAME.asc())
+        return firstRecord(select)?.let(::fromRecord)
+    }
+
     suspend fun existsForSubject(subjectId: UUID): Boolean =
         existsWhere(TagTable.TAG.SUBJECT_ID.eq(subjectId))
 


### PR DESCRIPTION
After #263 tightened `atMostOneRecord` to `SelectLimitStep<R>` and added its own `.limit(2)` to enforce the ≤1 invariant, callers that intentionally want the top row of a fan-out (latest payment of N, latest error of a retry chain, latest match) no longer have a clean helper. Today they either bypass via `queryExecutor.executeSelect(...).singleOrNull()` or chain `allRecords(select.limit(1)).firstOrNull()`.

`firstRecord(select: SelectLimitStep<R>): R?` is the missing primitive — applies `.limit(1)` internally and returns the first row, with no duplicate check. Added on `AbstractJooqRepository` (covers `JooqBaseModelRepository` and `JooqAggregateRepository` via inheritance) and mirrored on `JooqBaseEntityRepository`.

`findLast(condition, sortField)` keeps its current shape; it covers single-table desc-only cases, and `firstRecord` covers the joins / custom projections / custom orderings that `findLast` can't express.
