### PR TITLE
Introduce tri-state constraint name resolution

### DIFF
--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -9,6 +9,7 @@ import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
 import com.razz.eva.tracing.QueryTracingListenerProvider
 import io.opentelemetry.api.OpenTelemetry
@@ -82,12 +83,13 @@ class JdbcQueryExecutor(
             .toTypedArray(),
     ).coerce(table).fetch()
 
-    override fun extractConstraintName(ex: Exception): String? {
+    override fun extractConstraintName(ex: Exception): Constraint? {
         val dataAccessException = ex as? DataAccessException ?: return null
-        return dataAccessException.getCause(PSQLException::class.java)?.serverErrorMessage?.constraint
+        val name = dataAccessException.getCause(PSQLException::class.java)?.serverErrorMessage?.constraint
+        return Constraint(name)
     }
 
-    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): String? {
+    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): Constraint? {
         if ((ex as? DataAccessException)?.sqlState() != PG_UNIQUE_VIOLATION) {
             return null
         }
@@ -96,8 +98,9 @@ class JdbcQueryExecutor(
         return if (table.comment == "PARTITIONED") {
             constraintName
         } else {
-            table.keys.firstOrNull { it.name == constraintName }?.name
-                ?: table.indexes.firstOrNull { it.unique && it.name == constraintName }?.name
+            val nonPartitionedConstraint = table.keys.firstOrNull { it.name == constraintName?.name }?.name
+                ?: table.indexes.firstOrNull { it.unique && it.name == constraintName?.name }?.name
+            Constraint(nonPartitionedConstraint)
         }
     }
 
@@ -107,13 +110,13 @@ class JdbcQueryExecutor(
             dae.sqlState() == PG_UNIQUE_VIOLATION -> UniqueModelRecordViolationException(
                 modelId = modelId,
                 tableName = table.name,
-                constraintName = extractUniqueConstraintName(dae, table),
+                constraintName = extractUniqueConstraintName(dae, table)?.name,
             )
 
             dae.sqlStateClass() == C23_INTEGRITY_CONSTRAINT_VIOLATION -> ModelRecordConstraintViolationException(
                 modelId = modelId,
                 tableName = table.name,
-                constraintName = extractConstraintName(dae),
+                constraintName = extractConstraintName(dae)?.name,
             )
 
             // https://www.postgresql.org/message-id/flat/CANbGkDhq9gZnEouo2PZHP3HGMAJKk7fZf3eU3Q8g46Y-1uGZ-w%40mail.gmail.com#e5de345d77abe0184e394f0701bb8bc5

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -9,6 +9,7 @@ import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
 import io.vertx.core.json.Json
 import io.vertx.kotlin.coroutines.coAwait
@@ -141,11 +142,21 @@ class VertxQueryExecutor(
         return record.into(table)
     }
 
-    override fun extractConstraintName(ex: Exception): String? = (ex as? PgException)?.constraint
+    override fun extractConstraintName(ex: Exception): Constraint? {
+        if (ex !is PgException) {
+            return null
+        }
 
-    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): String? {
-        return when ((ex as? PgException)?.sqlState) {
-            PG_UNIQUE_VIOLATION -> ex.constraint
+        return Constraint(ex.constraint)
+    }
+
+    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): Constraint? {
+        if (ex !is PgException) {
+            return null
+        }
+
+        return when (ex.sqlState) {
+            PG_UNIQUE_VIOLATION -> Constraint(ex.constraint)
             else -> null
         }
     }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -28,9 +28,12 @@ interface QueryExecutor {
         jooqQuery: DMLQuery<R>,
     ): Int
 
-    fun extractConstraintName(ex: Exception): String?
+    fun extractConstraintName(ex: Exception): Constraint?
 
-    fun extractUniqueConstraintName(ex: Exception, table: Table<*>): String?
+    fun extractUniqueConstraintName(ex: Exception, table: Table<*>): Constraint?
 
     fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException?
+
+    @JvmInline
+    value class Constraint(val name: String?)
 }

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
@@ -104,7 +104,7 @@ class JooqEventRepository(
                 uowId = uowEvent.id.uuidValue(),
                 uowName = uowEvent.uowName.stringValue(),
                 idempotencyKey = uowEvent.idempotencyKey,
-                constraintName = uniqueConstraintName,
+                constraintName = uniqueConstraintName.name,
             )
         }
 

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
@@ -5,6 +5,7 @@ import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.QueryExecuted
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.SelectExecuted
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.StoreExecuted
+import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
 import org.jooq.Record
@@ -68,9 +69,9 @@ class FakeMemorizingQueryExecutor(
             .execute(jooqQuery.getSQL(INLINED))
     }
 
-    override fun extractConstraintName(ex: Exception): String? = null
+    override fun extractConstraintName(ex: Exception): Constraint? = null
 
-    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): String? = null
+    override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): Constraint? = null
 
     override fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException? = null
 


### PR DESCRIPTION
There is a case when a constraint violation was produced not by the database itself, but by a trigger, which will result in a constraint name to be absent.