### PR TITLE
modelParam: hold New/Dirty on retry instead of re-querying a non-persisted model

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
@@ -65,7 +65,8 @@ class ModelParam<MID : ModelId<out Comparable<*>>, M : Model<MID, *>> private co
             staleAfter: Duration?,
             modelQueries: suspend (MID) -> M,
         ): ModelParam<MID, M> {
-            return if (attempt == 0) {
+            // On retry re-query only a persisted model; New/Dirty lack a committed identity, so hold them.
+            return if (attempt == 0 || !model.isPersisted()) {
                 ModelParam(model, staleAfter, modelQueries)
             } else {
                 ModelParam(model.id(), modelQueries)

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -249,7 +249,7 @@ class UnitOfWorkExecutor(
             true
         } ?: false
 
-    @Suppress("UNCHECKED_CAST")
+    @Suppress("UNCHECKED_CAST", "UnreachableCode")
     private fun <PRINCIPAL, PARAMS, RESULT, UOW> create(
         executionContext: ExecutionContext,
         target: KClass<UOW>,

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
@@ -22,9 +22,9 @@ class ModelParamSpec : FunSpec({
         modelParam.model().id() shouldBe model.id()
     }
 
-    test("Model param returns model obtained from queries when constructed second time from model") {
-        val oldModel = TestModel.createdTestModel("lel", 1337)
-        val newModel = oldModel.changeParam1("pek").changeParam2(100500)
+    test("Model param re-queries a persisted model when constructed second time from model") {
+        val oldModel = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337)
+        val newModel = TestModel.existingCreatedTestModel(id = oldModel.id(), param1 = "pek", param2 = 100500)
         var queryCount = 0
         val modelParam = InstantiationContext(1).modelParam(oldModel) { id ->
             queryCount++
@@ -35,6 +35,19 @@ class ModelParamSpec : FunSpec({
         modelParam.model().param2 shouldBe newModel.param2
         modelParam.model().id() shouldBe oldModel.id()
         queryCount shouldBe 1
+    }
+
+    test("Model param holds a New model on retry instead of re-querying a never-committed id") {
+        val newModel = TestModel.createdTestModel("lel", 1337)
+        val modelParam = InstantiationContext(1).modelParam(newModel) { error("must not re-query a New model") }
+        modelParam.model().id() shouldBe newModel.id()
+        modelParam.model().param1 shouldBe newModel.param1
+    }
+
+    test("Model param holds a Dirty model on retry instead of dropping its uncommitted events") {
+        val dirtyModel = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337).changeParam1("pek")
+        val modelParam = InstantiationContext(1).modelParam(dirtyModel) { error("must not re-query a Dirty model") }
+        modelParam.model().param1 shouldBe "pek"
     }
 
     test("Model param re-queries when the held model is older than staleAfter") {

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -122,7 +122,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
         var tick = ofEpochMilli(0)
         val crawlingInstant = InstantSource {
-            var tock = tick.plusMillis(1)
+            val tock = tick.plusMillis(1)
             tick = tock.plusMillis(1)
             tock
         }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/StaleRecordSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/StaleRecordSpec.kt
@@ -104,7 +104,7 @@ class StaleRecordSpec : PersistenceBaseSpec({
                     departmentRepo.find(department.id())?.headcount shouldBe 5
                     avengers.size shouldBe 3
                     avengers.forEach { sp ->
-                        val persisted = employeeRepo.find(sp.id())!!
+                        val persisted = requireNotNull(employeeRepo.find(sp.id()))
                         persisted.departmentId shouldBe department.id()
                         persisted.version() shouldBe sp.version()
                         sp.isPersisted() shouldBe true


### PR DESCRIPTION
`modelParam(model, queries)` only re-queries safely for a Persistent model. On a top-level retry it currently re-queries by id regardless of state, so at an External site a New model re-queries a never-committed id, and a Dirty model loses its uncommitted events (green at attempt 0, wrong only on retry). Fix: hold New/Dirty on retry, re-query only Persistent.

```kotlin
return if (attempt == 0 || !model.isPersisted()) {
    ModelParam(model, staleAfter, modelQueries)   // hold
} else {
    ModelParam(model.id(), modelQueries)          // Persistent: re-query fresh
}
```

No caller changes; Persistent behavior (the common case) is unchanged. New/Dirty have no safely re-queryable committed identity, so holding the (rebuilt-each-attempt) instance is correct.

Second commit fixes 3 pre-existing detekt violations in eva-uow that otherwise fail this branch's detekt: `!!` -> `requireNotNull` (StaleRecordSpec), `var` -> `val` (UnitOfWorkExecutorSpec), and `@Suppress("UnreachableCode")` for a K2 / detekt-2.0-alpha false positive on `create()` in UnitOfWorkExecutor (the `?: throw` there is reachable; if it weren't, `execute(KClass)` would always throw).

Tests: `ModelParamSpec` gains held-on-retry cases for New and Dirty. detekt: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
