### PR TITLE
Add a way to return a value from UoW without persisting uow_events

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/BaseUnitOfWork.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/BaseUnitOfWork.kt
@@ -23,9 +23,34 @@ abstract class BaseUnitOfWork<PRINCIPAL, PARAMS, RESULT, C>(
 
     private val NO_CHANGES: Changes<Unit> = RealisedChanges(Unit, listOf(), listOf())
 
+    /**
+     * Signals that this UoW mutated no models: the executor persists no model/entity changes but still
+     * writes a uow_event, recording the invocation in the audit trail (and honoring any idempotency key).
+     * Use [abstain] instead when even that empty event is unwanted.
+     */
     protected fun noChanges() = NO_CHANGES
 
+    /**
+     * Same as [noChanges] but carries a [result] to return to the caller. The empty uow_event is still
+     * written; use [abstain] with the same [result] to skip it entirely.
+     */
     protected fun <R> noChanges(result: R): Changes<R> = RealisedChanges(result, listOf(), listOf())
+
+    private val ABSTAINED: Changes<Unit> = Abstained(Unit)
+
+    /**
+     * Like [noChanges] but additionally skips writing the uow_event: the executor returns without opening
+     * a persistence transaction at all. Use on the "get" branch of a get-or-create UoW, where the model
+     * already existed and no side effect was performed, to avoid an empty uow_event per call. Because no
+     * event is written, no idempotency key is recorded for the invocation.
+     */
+    protected fun abstain() = ABSTAINED
+
+    /**
+     * Same as [abstain] but carries a [result] to return to the caller. No uow_event is written and no
+     * persistence transaction is opened, so no idempotency key is recorded for the invocation.
+     */
+    protected fun <R> abstain(result: R): Changes<R> = Abstained(result)
 
     protected abstract suspend fun changes(init: suspend C.() -> RESULT): Changes<RESULT>
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
@@ -5,9 +5,9 @@ import com.razz.eva.domain.CreatableEntity
 import com.razz.eva.domain.DeletableEntity
 import com.razz.eva.domain.EntityKey
 import com.razz.eva.domain.Model
-import com.razz.eva.domain.UpdatableEntity
 import com.razz.eva.domain.ModelEvent
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.UpdatableEntity
 import kotlin.reflect.KClass
 
 private fun existingChangeExceptionMessage(modelId: ModelId<*>) =
@@ -152,3 +152,16 @@ internal class RealisedChanges<R>(
     override val entityChangesToPersist: List<EntityChange>,
     override val resultBuilder: ((PersistedLookup) -> Any?)? = null,
 ) : Changes<R>()
+
+/**
+ * Signals that nothing changed AND no uow_event should be written: the executor returns [result]
+ * without opening a persistence transaction. Contrast with [RealisedChanges] carrying empty changes
+ * (produced by `noChanges(...)`), which still records an empty uow_event as an audit trail of the
+ * invocation. Intended for get-or-create style UoWs whose "get" branch performed no side effect.
+ */
+internal class Abstained<R>(
+    override val result: R,
+) : Changes<R>() {
+    override val modelChangesToPersist: List<ModelChange> get() = emptyList()
+    override val entityChangesToPersist: List<EntityChange> get() = emptyList()
+}

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -29,7 +29,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
 import java.time.InstantSource
-import kotlin.collections.flatMap
 import kotlin.reflect.KClass
 
 infix fun <PRINCIPAL, PARAMS, RESULT, UOW> KClass<UOW>.withFactory(
@@ -120,6 +119,11 @@ class UnitOfWorkExecutor(
                     principal.id.toString(),
                 )
                 incrementEventsMetric(changes.modelChangesToPersist, name)
+                if (changes is Abstained) {
+                    // Get-or-create "get" path: nothing changed, so skip the persistence
+                    // transaction and the uow_event write entirely, returning the result as-is.
+                    return changes.result
+                }
                 val (uowId, persisted) = try {
                     withContext(uowSpan.asContextElement()) {
                         persistingSpan(name).use {

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -26,7 +26,7 @@ import com.razz.eva.repository.hasRepo
 import com.razz.eva.test.tracing.OpenTelemetryTestConfiguration
 import com.razz.eva.uow.BaseUnitOfWork.Configuration
 import com.razz.eva.uow.Clocks.fixedUTC
-import com.razz.eva.uow.CreateDepartmentUow.Params
+import com.razz.eva.uow.GetOrCreateDepartmentUow.Params
 import com.razz.eva.uow.Retry.StaleRecordFixedRetry
 import com.razz.eva.uow.composable.DummyUow
 import com.razz.eva.uow.params.kotlinx.KotlinxParamsSerializer
@@ -478,8 +478,8 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
         And("Two ClassToUow with the same key") {
             val factories = listOf(
-                CreateDepartmentUow::class withFactory { mockk() },
-                CreateDepartmentUow::class withFactory { mockk() },
+                GetOrCreateDepartmentUow::class withFactory { mockk() },
+                GetOrCreateDepartmentUow::class withFactory { mockk() },
             )
 
             When("Principal creates UnitOfWorkExecutor") {
@@ -489,7 +489,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 Then("Exception is thrown") {
                     val ex = shouldThrow<IllegalArgumentException> { attempt() }
-                    ex.message shouldBe "Attempted to register multiple factories for CreateDepartmentUow"
+                    ex.message shouldBe "Attempted to register multiple factories for GetOrCreateDepartmentUow"
                 }
             }
         }
@@ -512,17 +512,17 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                     ),
                 ),
             )
-            val unitOfWork = mockk<CreateDepartmentUow>()
+            val unitOfWork = mockk<GetOrCreateDepartmentUow>()
             val rawUnitOfWork = unitOfWork as UnitOfWork<TestPrincipal, Params, OwnedDepartment>
             val persisting = mockk<Persisting>(relaxed = true)
 
-            every { unitOfWork.name() } returns "MockOfCreateDepartmentUow"
+            every { unitOfWork.name() } returns "MockOfGetOrCreateDepartmentUow"
             every { rawUnitOfWork.configuration().supportsOutOfOrderPersisting } returns true
 
             val uowx = UnitOfWorkExecutor(
                 persisting = persisting,
                 factories = listOf(
-                    CreateDepartmentUow::class withFactory { unitOfWork },
+                    GetOrCreateDepartmentUow::class withFactory { unitOfWork },
                 ),
                 clock = clock,
                 openTelemetry = OpenTelemetry.noop(),
@@ -531,7 +531,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
             And("UnitOfWork has one retry and returns result") {
                 coEvery {
                     persisting.persist(
-                        uowName = "MockOfCreateDepartmentUow",
+                        uowName = "MockOfGetOrCreateDepartmentUow",
                         params = params,
                         principal = TestPrincipal,
                         modelChanges = listOf(),
@@ -548,7 +548,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns changes
 
                 When("Principal executes UnitOfWork") {
-                    val createdDepartment = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    val createdDepartment = uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Correct result will be returned") {
                         createdDepartment shouldBe department
@@ -557,7 +557,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                     And("Changes are persisted") {
                         coVerify {
                             persisting.persist(
-                                uowName = "MockOfCreateDepartmentUow",
+                                uowName = "MockOfGetOrCreateDepartmentUow",
                                 params = params,
                                 principal = TestPrincipal,
                                 modelChanges = changes.modelChangesToPersist,
@@ -577,7 +577,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 When("Principal executes UnitOfWork") {
                     val attempt = suspend {
-                        uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                        uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
                     }
 
                     Then("Exception is returned") {
@@ -597,7 +597,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns Abstained(department)
 
                 When("Principal executes UnitOfWork") {
-                    val result = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    val result = uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Result is returned as-is") {
                         result shouldBe department
@@ -619,7 +619,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        uowName = "MockOfCreateDepartmentUow",
+                        uowName = "MockOfGetOrCreateDepartmentUow",
                         params = params,
                         principal = TestPrincipal,
                         modelChanges = listOf(),
@@ -631,7 +631,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } throws ex
 
                 When("Principal executes UnitOfWork") {
-                    val createdDepartment = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    val createdDepartment = uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Correct result will be returned") {
                         createdDepartment shouldBe department
@@ -651,7 +651,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -663,7 +663,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
 
                 When("Principal executes UnitOfWork") {
-                    val createdDepartment = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    val createdDepartment = uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Correct result will be returned") {
                         createdDepartment shouldBe department
@@ -681,7 +681,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -694,7 +694,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 When("Principal executes UnitOfWork") {
                     val execution = suspend {
-                        uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                        uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
                     }
 
                     Then("Exception will be thrown") {
@@ -714,7 +714,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -729,7 +729,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 When("Principal executes UnitOfWork") {
                     val execution = suspend {
-                        uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                        uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
                     }
 
                     Then("Exception will be thrown") {
@@ -747,7 +747,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -760,7 +760,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 When("Principal executes UnitOfWork") {
                     val execution = suspend {
-                        uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                        uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
                     }
 
                     Then("Exception will be thrown") {
@@ -777,7 +777,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -790,7 +790,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
                 When("Principal executes UnitOfWork") {
                     val execution = suspend {
-                        uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                        uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
                     }
 
                     Then("Exception will be thrown") {
@@ -808,7 +808,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns RealisedChanges(department, listOf(), listOf())
                 coEvery {
                     persisting.persist(
-                        "MockOfCreateDepartmentUow",
+                        "MockOfGetOrCreateDepartmentUow",
                         eq(params),
                         TestPrincipal,
                         listOf(),
@@ -820,7 +820,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns resultModel
 
                 When("Principal executes UnitOfWork") {
-                    val result = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    val result = uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Result is correct") {
                         result shouldBe resultModel
@@ -830,8 +830,8 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
         }
 
         And("Persistence exception counter metric") {
-            val uowName = "MockOfCreateDepartmentUow"
-            val unitOfWork = mockk<CreateDepartmentUow>()
+            val uowName = "MockOfGetOrCreateDepartmentUow"
+            val unitOfWork = mockk<GetOrCreateDepartmentUow>()
             val rawUnitOfWork = unitOfWork as UnitOfWork<TestPrincipal, Params, OwnedDepartment>
             val persisting = mockk<Persisting>(relaxed = true)
             every { unitOfWork.name() } returns uowName
@@ -843,7 +843,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
             val metricReader = InMemoryMetricReader.create()
             val uowx = UnitOfWorkExecutor(
                 persisting = persisting,
-                factories = listOf(CreateDepartmentUow::class withFactory { unitOfWork }),
+                factories = listOf(GetOrCreateDepartmentUow::class withFactory { unitOfWork }),
                 clock = clock,
                 openTelemetry = OpenTelemetryTestConfiguration.create(metricReader = metricReader),
             )
@@ -863,7 +863,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } throws ex andThen Pair(UowEvent.Id.random(), listOf(department))
 
                 When("Principal executes UnitOfWork") {
-                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Counter records a single retried conflict at attempt 0") {
                         metricReader.persistenceExceptionPoints() shouldBe listOf(
@@ -889,7 +889,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
 
                 When("Principal executes UnitOfWork") {
-                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Counter records the retried conflict and the exhausted failure") {
                         metricReader.persistenceExceptionPoints().toSet() shouldBe setOf(
@@ -914,7 +914,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 } returns Pair(UowEvent.Id.random(), listOf(department))
 
                 When("Principal executes UnitOfWork") {
-                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Counter is not incremented") {
                         metricReader.persistenceExceptionPoints() shouldBe listOf()
@@ -938,7 +938,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
 
                 When("Principal executes UnitOfWork") {
-                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Counter records the constraint table and a non-retried failure at attempt 0") {
                         metricReader.persistenceExceptionPoints() shouldBe listOf(
@@ -964,7 +964,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
 
                 When("Principal executes UnitOfWork") {
-                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+                    uowx.execute(GetOrCreateDepartmentUow::class, TestPrincipal) { params }
 
                     Then("Counter falls back to the unknown table") {
                         metricReader.persistenceExceptionPoints() shouldBe listOf(

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -26,9 +26,10 @@ import com.razz.eva.repository.hasRepo
 import com.razz.eva.test.tracing.OpenTelemetryTestConfiguration
 import com.razz.eva.uow.BaseUnitOfWork.Configuration
 import com.razz.eva.uow.Clocks.fixedUTC
-import com.razz.eva.uow.params.kotlinx.KotlinxParamsSerializer
 import com.razz.eva.uow.CreateDepartmentUow.Params
 import com.razz.eva.uow.Retry.StaleRecordFixedRetry
+import com.razz.eva.uow.composable.DummyUow
+import com.razz.eva.uow.params.kotlinx.KotlinxParamsSerializer
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode.InstancePerLeaf
 import io.kotest.core.spec.style.BehaviorSpec
@@ -44,11 +45,10 @@ import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import java.time.Duration.ofMillis
 import java.time.Instant.ofEpochMilli
-import java.util.*
-import com.razz.eva.uow.composable.DummyUow
-import com.razz.eva.uow.composable.UnitOfWork as ComposableUnitOfWork
-import kotlin.reflect.KClass
 import java.time.InstantSource
+import java.util.UUID
+import kotlin.reflect.KClass
+import com.razz.eva.uow.composable.UnitOfWork as ComposableUnitOfWork
 
 class UnitOfWorkExecutorSpec : BehaviorSpec({
 
@@ -586,6 +586,24 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                     }
 
                     And("No changes are persisted") {
+                        verify { persisting wasNot Called }
+                    }
+                }
+            }
+
+            And("UnitOfWork abstains (get-or-create get path)") {
+                coEvery {
+                    rawUnitOfWork.tryPerform(TestPrincipal, eq(params))
+                } returns Abstained(department)
+
+                When("Principal executes UnitOfWork") {
+                    val result = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Result is returned as-is") {
+                        result shouldBe department
+                    }
+
+                    And("Nothing is persisted and no uow_event is written") {
                         verify { persisting wasNot Called }
                     }
                 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkSpec.kt
@@ -1,18 +1,22 @@
 package com.razz.eva.uow
 
 import com.razz.eva.domain.Department.OwnedDepartment
+import com.razz.eva.domain.DepartmentId
 import com.razz.eva.domain.EmployeeId
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.ModelId
+import com.razz.eva.domain.ModelState.PersistentState.Companion.persistentState
 import com.razz.eva.domain.Ration.BUBALEH
 import com.razz.eva.domain.Ration.SHAKSHOUKA
+import com.razz.eva.domain.Version.Companion.V1
 import com.razz.eva.repository.DepartmentRepository
 import com.razz.eva.test.uow.UowBehaviorSpec
-import com.razz.eva.uow.CreateDepartmentUow.Params
+import com.razz.eva.uow.GetOrCreateDepartmentUow.Params
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.mockk
 import java.util.UUID.randomUUID
@@ -21,7 +25,7 @@ class UnitOfWorkSpec : UowBehaviorSpec({
 
     Given("A simple UnitOfWork with repository") {
         val departmentRepo = mockk<DepartmentRepository>()
-        val uow = CreateDepartmentUow(executionContext, departmentRepo)
+        val uow = GetOrCreateDepartmentUow(executionContext, departmentRepo)
             as UnitOfWork<TestPrincipal, Params, OwnedDepartment>
 
         And("Department is not found") {
@@ -57,6 +61,33 @@ class UnitOfWorkSpec : UowBehaviorSpec({
                             }
                         })
                     }
+                }
+            }
+        }
+
+        And("Department is found") {
+            val empId = EmployeeId(randomUUID())
+            val existing = OwnedDepartment(
+                id = DepartmentId(randomUUID()),
+                name = "Skunk works",
+                boss = empId,
+                headcount = 1,
+                ration = SHAKSHOUKA,
+                modelState = persistentState(V1, null),
+            )
+            coEvery { departmentRepo.findByBoss(empId) } answers { existing }
+
+            When("Principal executes unit of work") {
+                val changes = uow.tryPerform(TestPrincipal, Params(empId, "Skunk works", SHAKSHOUKA))
+
+                Then("The existing Department is returned as-is") {
+                    changes.result shouldBe existing
+                }
+
+                And("Changes abstain, so nothing is persisted and no uow_event is written") {
+                    changes.shouldBeInstanceOf<Abstained<OwnedDepartment>>()
+                    changes.modelChangesToPersist shouldBe emptyList()
+                    changes.entityChangesToPersist shouldBe emptyList()
                 }
             }
         }

--- a/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/GetOrCreateDepartmentUow.kt
+++ b/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/GetOrCreateDepartmentUow.kt
@@ -7,12 +7,12 @@ import com.razz.eva.domain.EmployeeId
 import com.razz.eva.domain.ModelState.NewState.Companion.newState
 import com.razz.eva.domain.Ration
 import com.razz.eva.repository.DepartmentRepository
-import com.razz.eva.uow.CreateDepartmentUow.Params
+import com.razz.eva.uow.GetOrCreateDepartmentUow.Params
 import com.razz.eva.uow.params.kotlinx.UowParams
 import kotlinx.serialization.Serializable
-import java.util.*
+import java.util.UUID
 
-class CreateDepartmentUow(
+class GetOrCreateDepartmentUow(
     executionContext: ExecutionContext,
     private val departmentRepo: DepartmentRepository
 ) : UnitOfWork<TestPrincipal, Params, OwnedDepartment>(executionContext) {
@@ -26,17 +26,15 @@ class CreateDepartmentUow(
         override fun serialization() = serializer()
     }
 
-    override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<OwnedDepartment> =
-        changes {
-            addDepartment(params.boss, params.departmentName, params.ration)
-        }
-
-    private suspend fun ChangesDsl.addDepartment(boss: EmployeeId, name: String, ration: Ration): OwnedDepartment {
-        val existingDep = departmentRepo.findByBoss(boss)
+    override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<OwnedDepartment> {
+        val existingDep = departmentRepo.findByBoss(params.boss)
         return if (existingDep != null) {
-            throw IllegalStateException("Department already exists")
+            // Get path: the department already exists, so return it without recording a uow_event.
+            abstain(existingDep)
         } else {
-            add(createDep(boss, name, ration))
+            changes {
+                add(createDep(params.boss, params.departmentName, params.ration))
+            }
         }
     }
 


### PR DESCRIPTION
This is added for get-or-create pattern, when you don't really need to write an event when you "get" a model.