### PR TITLE
Add WriteTxScope: opt-in FULL_UOW transaction spanning tryPerform and flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,20 @@ override suspend fun onFailure(params: Params, ex: PersistenceException): Wallet
 }
 ```
 
+### Write transaction scope
+By default a unit of work runs `tryPerform` reads on the primary outside of a transaction, each on its own pooled connection,
+and opens the write transaction only for the flush (`WriteTxScope.FLUSH`).
+A fast, database-bound unit of work can opt into `WriteTxScope.FULL_UOW`: one transaction on a single pooled connection
+spans `tryPerform` and the flush, and reads join it through the connection in the coroutine context,
+cutting pool acquisitions from one per read plus one for the flush down to one per attempt.
+```kotlin
+val configuration = UnitOfWork.Configuration(
+    writeTxScope = WriteTxScope.FULL_UOW,
+)
+```
+The connection and the open transaction are held for the whole attempt, so do not use `FULL_UOW` for units of work
+that call external services, do heavy CPU work or run parallel reads inside `tryPerform`.
+
 ### Tracing and Monitoring
 If you care about your system's performance, you want to collect metrics so you can create alerts and investigate issues.
 We allow you to collect some metrics via [Micrometer framework](https://micrometer.io/) and do instrumentation with [Opentracing](https://opentracing.io/).

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/BaseUnitOfWork.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/BaseUnitOfWork.kt
@@ -35,6 +35,7 @@ abstract class BaseUnitOfWork<PRINCIPAL, PARAMS, RESULT, C>(
         val retry: Retry? = DEFAULT,
         val supportsOutOfOrderPersisting: Boolean = false,
         val returnRoundtrippedModels: Boolean = true,
+        val writeTxScope: WriteTxScope = WriteTxScope.FLUSH,
     ) {
         companion object {
             fun default() = Configuration()

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Persisting.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Persisting.kt
@@ -4,6 +4,7 @@ import com.razz.eva.domain.Model
 import com.razz.eva.domain.Principal
 import com.razz.eva.events.EventPublisher
 import com.razz.eva.events.UowEvent
+import com.razz.eva.persistence.ConnectionMode
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.repository.EntityRepos
@@ -58,8 +59,10 @@ class Persisting(
         entityChanges: Collection<EntityChange>,
         now: Instant,
         uowSupportsOutOfOrderPersisting: Boolean,
-    ): Pair<UowEvent.Id, List<Model<*, *>>> {
-        val (uowEvent, flushed) = inTransaction(now, uowSupportsOutOfOrderPersisting) { persisting, startedAt ->
+        connectionMode: ConnectionMode,
+    ): Pair<UowEvent, List<Model<*, *>>> {
+        val (uowEvent, flushed) = inTransaction(now, uowSupportsOutOfOrderPersisting, connectionMode) {
+                persisting, startedAt ->
             val events = modelChanges.flatMap(ModelChange::modelEvents)
             modelChanges.forEach { change ->
                 change.persist(persisting)
@@ -77,13 +80,27 @@ class Persisting(
                 occurredAt = startedAt,
             )
         }
+        return uowEvent to flushed
+    }
+
+    internal suspend fun publish(uowEvent: UowEvent) {
         eventPublisher.publish(uowEvent)
-        return uowEvent.id to flushed
+    }
+
+    /**
+     * Opens the write transaction the executor scopes a whole [WriteTxScope.FULL_UOW] attempt in;
+     * [persist] then joins it with [ConnectionMode.REQUIRE_EXISTING].
+     */
+    internal suspend fun <R> transactionally(block: suspend () -> R): R {
+        return transactionManager.inTransaction(REQUIRE_NEW) { _ ->
+            block()
+        }
     }
 
     private suspend fun inTransaction(
         now: Instant,
         uowSupportsOutOfOrderPersisting: Boolean,
+        connectionMode: ConnectionMode,
         block: (PersistingAccumulator, Instant) -> UowEvent,
     ): Pair<UowEvent, List<Model<*, *>>> {
         val persistingMode = if (transactionManager.supportsPipelining() && uowSupportsOutOfOrderPersisting) {
@@ -93,7 +110,7 @@ class Persisting(
         }
         val persisting = newPersistingAccumulator(uowSupportsOutOfOrderPersisting, modelRepos, entityRepos)
         val uowEvent = block(persisting, now)
-        val flushed = transactionManager.inTransaction(REQUIRE_NEW) { _ ->
+        val flushed = transactionManager.inTransaction(connectionMode) { _ ->
             flush(persisting, uowEvent, transactionalContext(now), persistingMode)
         }
         return uowEvent to flushed

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -116,11 +116,23 @@ class UnitOfWorkExecutor(
                     WriteTxScope.FLUSH -> {
                         // tryPerform stays outside the conflict handling: its persistence exceptions
                         // propagate raw instead of routing to retry/onFailure
-                        val changes = performAttempt(uow, principal, constructedParams, name, uowSpan)
+                        val changes = performAttempt(
+                            uow = uow,
+                            principal = principal,
+                            params = constructedParams,
+                            name = name,
+                            uowSpan = uowSpan,
+                        )
                         try {
                             persistAttempt(
-                                uow, principal, constructedParams, changes, now,
-                                name, uowSpan, REQUIRE_NEW,
+                                uow = uow,
+                                principal = principal,
+                                params = constructedParams,
+                                changes = changes,
+                                now = now,
+                                name = name,
+                                uowSpan = uowSpan,
+                                connectionMode = REQUIRE_NEW,
                             )
                         } catch (ex: PersistenceException) {
                             Attempted.Conflict(ex)
@@ -128,11 +140,22 @@ class UnitOfWorkExecutor(
                     }
                     WriteTxScope.FULL_UOW -> try {
                         persisting.transactionally {
-                            val changes =
-                                performAttempt(uow, principal, constructedParams, name, uowSpan)
+                            val changes = performAttempt(
+                                uow = uow,
+                                principal = principal,
+                                params = constructedParams,
+                                name = name,
+                                uowSpan = uowSpan,
+                            )
                             persistAttempt(
-                                uow, principal, constructedParams, changes, now,
-                                name, uowSpan, REQUIRE_EXISTING,
+                                uow = uow,
+                                principal = principal,
+                                params = constructedParams,
+                                changes = changes,
+                                now = now,
+                                name = name,
+                                uowSpan = uowSpan,
+                                connectionMode = REQUIRE_EXISTING,
                             )
                         }
                     } catch (ex: PersistenceException) {

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -112,56 +112,7 @@ class UnitOfWorkExecutor(
                     uowSpan.setAttribute(UOW_NAME, name)
                 }
                 val constructedParams = params(InstantiationContext.External(currentAttempt))
-                val attempted = when (uow.configuration().writeTxScope) {
-                    WriteTxScope.FLUSH -> {
-                        // tryPerform stays outside the conflict handling: its persistence exceptions
-                        // propagate raw instead of routing to retry/onFailure
-                        val changes = performAttempt(
-                            uow = uow,
-                            principal = principal,
-                            params = constructedParams,
-                            name = name,
-                            uowSpan = uowSpan,
-                        )
-                        try {
-                            persistAttempt(
-                                uow = uow,
-                                principal = principal,
-                                params = constructedParams,
-                                changes = changes,
-                                now = now,
-                                name = name,
-                                uowSpan = uowSpan,
-                                connectionMode = REQUIRE_NEW,
-                            )
-                        } catch (ex: PersistenceException) {
-                            Attempted.Conflict(ex)
-                        }
-                    }
-                    WriteTxScope.FULL_UOW -> try {
-                        persisting.transactionally {
-                            val changes = performAttempt(
-                                uow = uow,
-                                principal = principal,
-                                params = constructedParams,
-                                name = name,
-                                uowSpan = uowSpan,
-                            )
-                            persistAttempt(
-                                uow = uow,
-                                principal = principal,
-                                params = constructedParams,
-                                changes = changes,
-                                now = now,
-                                name = name,
-                                uowSpan = uowSpan,
-                                connectionMode = REQUIRE_EXISTING,
-                            )
-                        }
-                    } catch (ex: PersistenceException) {
-                        Attempted.Conflict(ex)
-                    }
-                }
+                val attempted = attempt(uow, principal, constructedParams, now, name, uowSpan)
                 val committed = when (attempted) {
                     is Attempted.Conflict -> {
                         val ex = attempted.ex
@@ -220,6 +171,69 @@ class UnitOfWorkExecutor(
         ) : Attempted<RESULT>
 
         class Conflict(val ex: PersistenceException) : Attempted<Nothing>
+    }
+
+    private suspend fun <PRINCIPAL, PARAMS, RESULT, UOW> attempt(
+        uow: UOW,
+        principal: PRINCIPAL,
+        params: PARAMS,
+        now: Instant,
+        name: String,
+        uowSpan: Span,
+    ): Attempted<RESULT> where PRINCIPAL : Principal<*>,
+          PARAMS : UowParams<PARAMS>,
+          RESULT : Any,
+          UOW : BaseUnitOfWork<PRINCIPAL, PARAMS, RESULT, *> {
+        return when (uow.configuration().writeTxScope) {
+            WriteTxScope.FLUSH -> {
+                // tryPerform stays outside the conflict handling: its persistence exceptions
+                // propagate raw instead of routing to retry/onFailure
+                val changes = performAttempt(
+                    uow = uow,
+                    principal = principal,
+                    params = params,
+                    name = name,
+                    uowSpan = uowSpan,
+                )
+                try {
+                    persistAttempt(
+                        uow = uow,
+                        principal = principal,
+                        params = params,
+                        changes = changes,
+                        now = now,
+                        name = name,
+                        uowSpan = uowSpan,
+                        connectionMode = REQUIRE_NEW,
+                    )
+                } catch (ex: PersistenceException) {
+                    Attempted.Conflict(ex)
+                }
+            }
+            WriteTxScope.FULL_UOW -> try {
+                persisting.transactionally {
+                    val changes = performAttempt(
+                        uow = uow,
+                        principal = principal,
+                        params = params,
+                        name = name,
+                        uowSpan = uowSpan,
+                    )
+                    persistAttempt(
+                        uow = uow,
+                        principal = principal,
+                        params = params,
+                        changes = changes,
+                        now = now,
+                        name = name,
+                        uowSpan = uowSpan,
+                        connectionMode = REQUIRE_EXISTING,
+                    )
+                }
+            } catch (ex: PersistenceException) {
+                Attempted.Conflict(ex)
+            }
+        }
     }
 
     private suspend fun <PRINCIPAL, PARAMS, RESULT, UOW> performAttempt(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -2,6 +2,10 @@ package com.razz.eva.uow
 
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.Principal
+import com.razz.eva.events.UowEvent
+import com.razz.eva.persistence.ConnectionMode
+import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
+import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
 import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.razz.eva.tracing.getEvaMeter
@@ -25,10 +29,12 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongHistogram
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
+import java.time.Instant
 import java.time.InstantSource
 import kotlin.collections.flatMap
 import kotlin.reflect.KClass
@@ -106,66 +112,70 @@ class UnitOfWorkExecutor(
                     uowSpan.setAttribute(UOW_NAME, name)
                 }
                 val constructedParams = params(InstantiationContext.External(currentAttempt))
-                val changes = timed(performTimer, name) {
-                    withContext(PrimaryConnectionRequiredFlag + uowSpan.asContextElement()) {
-                        performingSpan(name).use {
-                            uow.tryPerform(principal, constructedParams)
+                val attempted = when (uow.configuration().writeTxScope) {
+                    WriteTxScope.FLUSH -> {
+                        // tryPerform stays outside the conflict handling: its persistence exceptions
+                        // propagate raw instead of routing to retry/onFailure
+                        val changes = performAttempt(uow, principal, constructedParams, name, uowSpan)
+                        try {
+                            persistAttempt(
+                                uow, principal, constructedParams, changes, now,
+                                name, uowSpan, REQUIRE_NEW,
+                            )
+                        } catch (ex: PersistenceException) {
+                            Attempted.Conflict(ex)
                         }
                     }
+                    WriteTxScope.FULL_UOW -> try {
+                        persisting.transactionally {
+                            val changes =
+                                performAttempt(uow, principal, constructedParams, name, uowSpan)
+                            persistAttempt(
+                                uow, principal, constructedParams, changes, now,
+                                name, uowSpan, REQUIRE_EXISTING,
+                            )
+                        }
+                    } catch (ex: PersistenceException) {
+                        Attempted.Conflict(ex)
+                    }
                 }
-                uowSpan.setAttribute(
-                    MODEL_ID,
-                    changes.modelChangesToPersist.map { it.id.stringValue() },
-                )
-                uowSpan.setAttribute(
-                    PRINCIPAL_ID,
-                    principal.id.toString(),
-                )
-                incrementEventsMetric(changes.modelChangesToPersist, name)
-                val (uowId, persisted) = try {
-                    timed(persistTimer, name) {
-                        withContext(uowSpan.asContextElement()) {
-                            persistingSpan(name).use {
-                                persisting.persist(
-                                    uowName = uow.name(),
-                                    params = constructedParams,
-                                    principal = principal,
-                                    modelChanges = changes.modelChangesToPersist,
-                                    entityChanges = changes.entityChangesToPersist,
-                                    now = now,
-                                    uowSupportsOutOfOrderPersisting = uow.configuration()
-                                        .supportsOutOfOrderPersisting,
-                                )
+                val committed = when (attempted) {
+                    is Attempted.Conflict -> {
+                        val ex = attempted.ex
+                        uowSpan.addEvent(
+                            "persistence.exception",
+                            Attributes.of(
+                                SpanAttributes.peristenceException,
+                                ex::class.simpleName ?: "Unknown",
+                                SpanAttributes.modelIds,
+                                (ex as? PersistenceException.ModelAware)?.modelIds?.map { it.stringValue() }
+                                    ?: listOf(),
+                            ),
+                        )
+                        val config = uow.configuration()
+                        val willRetry = config.retry.shouldRetry(currentAttempt, ex)
+                        incrementPersistenceExceptionMetric(ex, name, currentAttempt, willRetry)
+                        if (willRetry) {
+                            currentAttempt += 1
+                            logger.warn(ex) {
+                                "Retrying UnitOfWork: ${uow.name()}. Attempt: $currentAttempt"
                             }
+                            continue
                         }
+                        return uow.onFailure(constructedParams, ex)
                     }
-                } catch (ex: PersistenceException) {
-                    uowSpan.addEvent(
-                        "persistence.exception",
-                        Attributes.of(
-                            SpanAttributes.peristenceException,
-                            ex::class.simpleName ?: "Unknown",
-                            SpanAttributes.modelIds,
-                            (ex as? PersistenceException.ModelAware)?.modelIds?.map { it.stringValue() } ?: listOf(),
-                        ),
-                    )
-                    val config = uow.configuration()
-                    val willRetry = config.retry.shouldRetry(currentAttempt, ex)
-                    incrementPersistenceExceptionMetric(ex, name, currentAttempt, willRetry)
-                    if (willRetry) {
-                        currentAttempt += 1
-                        logger.warn(ex) {
-                            "Retrying UnitOfWork: ${uow.name()}. Attempt: $currentAttempt"
-                        }
-                        continue
-                    }
-                    return uow.onFailure(constructedParams, ex)
+                    is Attempted.Committed -> attempted
                 }
+                persisting.publish(committed.uowEvent)
                 uowSpan.setAttribute(
                     UOW_ID,
-                    uowId.toString(),
+                    committed.uowEvent.id.toString(),
                 )
-                return if (uow.configuration().returnRoundtrippedModels) result(changes, persisted) else changes.result
+                return if (uow.configuration().returnRoundtrippedModels) {
+                    result(committed.changes, committed.persisted)
+                } else {
+                    committed.changes.result
+                }
             }
         } catch (ex: Exception) {
             uowSpan.recordException(ex)
@@ -176,6 +186,78 @@ class UnitOfWorkExecutor(
             timer.record(elapsedTime, Attributes.of(AttributeKey.stringKey("uow.name"), name))
             uowSpan.end()
         }
+    }
+
+    private sealed interface Attempted<out RESULT : Any> {
+
+        class Committed<RESULT : Any>(
+            val changes: Changes<RESULT>,
+            val uowEvent: UowEvent,
+            val persisted: List<Model<*, *>>,
+        ) : Attempted<RESULT>
+
+        class Conflict(val ex: PersistenceException) : Attempted<Nothing>
+    }
+
+    private suspend fun <PRINCIPAL, PARAMS, RESULT, UOW> performAttempt(
+        uow: UOW,
+        principal: PRINCIPAL,
+        params: PARAMS,
+        name: String,
+        uowSpan: Span,
+    ): Changes<RESULT> where PRINCIPAL : Principal<*>,
+          PARAMS : UowParams<PARAMS>,
+          RESULT : Any,
+          UOW : BaseUnitOfWork<PRINCIPAL, PARAMS, RESULT, *> {
+        val changes = timed(performTimer, name) {
+            withContext(PrimaryConnectionRequiredFlag + uowSpan.asContextElement()) {
+                performingSpan(name).use {
+                    uow.tryPerform(principal, params)
+                }
+            }
+        }
+        uowSpan.setAttribute(
+            MODEL_ID,
+            changes.modelChangesToPersist.map { it.id.stringValue() },
+        )
+        uowSpan.setAttribute(
+            PRINCIPAL_ID,
+            principal.id.toString(),
+        )
+        incrementEventsMetric(changes.modelChangesToPersist, name)
+        return changes
+    }
+
+    private suspend fun <PRINCIPAL, PARAMS, RESULT, UOW> persistAttempt(
+        uow: UOW,
+        principal: PRINCIPAL,
+        params: PARAMS,
+        changes: Changes<RESULT>,
+        now: Instant,
+        name: String,
+        uowSpan: Span,
+        connectionMode: ConnectionMode,
+    ): Attempted.Committed<RESULT> where PRINCIPAL : Principal<*>,
+          PARAMS : UowParams<PARAMS>,
+          RESULT : Any,
+          UOW : BaseUnitOfWork<PRINCIPAL, PARAMS, RESULT, *> {
+        val (uowEvent, persisted) = timed(persistTimer, name) {
+            withContext(uowSpan.asContextElement()) {
+                persistingSpan(name).use {
+                    persisting.persist(
+                        uowName = uow.name(),
+                        params = params,
+                        principal = principal,
+                        modelChanges = changes.modelChangesToPersist,
+                        entityChanges = changes.entityChangesToPersist,
+                        now = now,
+                        uowSupportsOutOfOrderPersisting = uow.configuration().supportsOutOfOrderPersisting,
+                        connectionMode = connectionMode,
+                    )
+                }
+            }
+        }
+        return Attempted.Committed(changes, uowEvent, persisted)
     }
 
     private fun <RESULT> result(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/WriteTxScope.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/WriteTxScope.kt
@@ -1,0 +1,25 @@
+package com.razz.eva.uow
+
+/**
+ * When the write transaction opens relative to [BaseUnitOfWork.tryPerform].
+ */
+enum class WriteTxScope {
+    /**
+     * Default. Reads inside [BaseUnitOfWork.tryPerform] run on the primary, un-transacted, each on its own
+     * pooled connection released per statement; the write transaction opens only for the flush.
+     * Minimal connection hold: write consistency comes from the version check, not a shared read snapshot.
+     */
+    FLUSH,
+
+    /**
+     * Opt-in. One transaction on one pooled connection spans [BaseUnitOfWork.tryPerform] and the flush;
+     * reads join it through the connection in the coroutine context. Cuts pool acquisitions from
+     * one per read plus one for the flush down to one per attempt.
+     *
+     * Only suitable for fast, database-bound units: the connection and the open transaction are held
+     * for the whole attempt. Do not use for units that call external services, do heavy CPU work or
+     * run parallel reads inside [BaseUnitOfWork.tryPerform] (parallel reads would serialise on the
+     * single connection).
+     */
+    FULL_UOW,
+}

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -10,6 +10,8 @@ import com.razz.eva.domain.Ration
 import com.razz.eva.domain.RationAllocation
 import com.razz.eva.domain.Tag
 import com.razz.eva.events.UowEvent
+import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
+import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
@@ -37,6 +39,7 @@ import io.kotest.matchers.shouldBe
 import io.mockk.Called
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -519,6 +522,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
 
             every { unitOfWork.name() } returns "MockOfCreateDepartmentUow"
             every { rawUnitOfWork.configuration().supportsOutOfOrderPersisting } returns true
+            every { rawUnitOfWork.configuration().writeTxScope } returns WriteTxScope.FLUSH
 
             val uowx = UnitOfWorkExecutor(
                 persisting = persisting,
@@ -539,8 +543,9 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
-                } returns Pair(UowEvent.Id.random(), listOf(anotherModel, department))
+                } returns Pair(uowEvent(), listOf(anotherModel, department))
                 every { rawUnitOfWork.configuration() } returns
                     Configuration(StaleRecordFixedRetry(1, ofMillis(100)), true)
                 val changes = RealisedChanges(department, listOf(), listOf())
@@ -565,6 +570,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                                 entityChanges = changes.entityChangesToPersist,
                                 now = clock.instant(),
                                 uowSupportsOutOfOrderPersisting = true,
+                                connectionMode = REQUIRE_NEW,
                             )
                         }
                     }
@@ -609,8 +615,9 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
-                } throws ex andThen Pair(UowEvent.Id.random(), listOf(department))
+                } throws ex andThen Pair(uowEvent(), listOf(department))
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } throws ex
 
                 When("Principal executes UnitOfWork") {
@@ -641,6 +648,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         true,
+                        REQUIRE_NEW,
                     )
                 } throws ex andThenThrows ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
@@ -671,6 +679,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         false,
+                        REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } throws StaleRecordException(depId, "department")
@@ -704,6 +713,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         false,
+                        REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery {
@@ -737,6 +747,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         false,
+                        REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } throws ex
@@ -767,6 +778,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         false,
+                        REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } throws ex
@@ -798,6 +810,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         listOf(),
                         ofEpochMilli(0),
                         false,
+                        REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns resultModel
@@ -842,8 +855,9 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
-                } throws ex andThen Pair(UowEvent.Id.random(), listOf(department))
+                } throws ex andThen Pair(uowEvent(), listOf(department))
 
                 When("Principal executes UnitOfWork") {
                     uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
@@ -879,6 +893,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
@@ -905,8 +920,9 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
-                } returns Pair(UowEvent.Id.random(), listOf(department))
+                } returns Pair(uowEvent(), listOf(department))
 
                 When("Principal executes UnitOfWork") {
                     uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
@@ -928,6 +944,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
@@ -954,6 +971,7 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = true,
+                        connectionMode = REQUIRE_NEW,
                     )
                 } throws ex
                 coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
@@ -969,8 +987,105 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
                 }
             }
         }
+
+        And("UnitOfWork with FULL_UOW write tx scope") {
+            val uowName = "MockOfCreateDepartmentUow"
+            val unitOfWork = mockk<CreateDepartmentUow>()
+            val rawUnitOfWork = unitOfWork as UnitOfWork<TestPrincipal, Params, OwnedDepartment>
+            val persisting = mockk<Persisting>(relaxed = true)
+            every { unitOfWork.name() } returns uowName
+            every { rawUnitOfWork.configuration() } returns Configuration(
+                retry = StaleRecordFixedRetry(1, ofMillis(0)),
+                writeTxScope = WriteTxScope.FULL_UOW,
+            )
+            coEvery {
+                rawUnitOfWork.tryPerform(TestPrincipal, eq(params))
+            } returns RealisedChanges(department, listOf(), listOf())
+            coEvery { persisting.transactionally(any<suspend () -> Any?>()) } coAnswers {
+                firstArg<suspend () -> Any?>().invoke()
+            }
+            val uowx = UnitOfWorkExecutor(
+                persisting = persisting,
+                factories = listOf(CreateDepartmentUow::class withFactory { unitOfWork }),
+                clock = clock,
+                openTelemetry = OpenTelemetry.noop(),
+            )
+
+            And("Persisting succeeds") {
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = false,
+                        connectionMode = REQUIRE_EXISTING,
+                    )
+                } returns Pair(uowEvent(), listOf(department))
+
+                When("Principal executes UnitOfWork") {
+                    val result = uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("Perform and persist run inside one transaction and publish follows the commit") {
+                        result shouldBe department
+                        coVerifyOrder {
+                            persisting.transactionally(any<suspend () -> Any?>())
+                            persisting.persist(
+                                uowName = uowName,
+                                params = params,
+                                principal = TestPrincipal,
+                                modelChanges = listOf(),
+                                entityChanges = listOf(),
+                                now = clock.instant(),
+                                uowSupportsOutOfOrderPersisting = false,
+                                connectionMode = REQUIRE_EXISTING,
+                            )
+                            persisting.publish(any())
+                        }
+                    }
+                }
+            }
+
+            And("Persisting throws StaleRecordException until retries are exhausted") {
+                val ex = StaleRecordException(depId, "departments")
+                coEvery {
+                    persisting.persist(
+                        uowName = uowName,
+                        params = params,
+                        principal = TestPrincipal,
+                        modelChanges = listOf(),
+                        entityChanges = listOf(),
+                        now = clock.instant(),
+                        uowSupportsOutOfOrderPersisting = false,
+                        connectionMode = REQUIRE_EXISTING,
+                    )
+                } throws ex
+                coEvery { rawUnitOfWork.onFailure(eq(params), eq(ex)) } returns department
+
+                When("Principal executes UnitOfWork") {
+                    uowx.execute(CreateDepartmentUow::class, TestPrincipal) { params }
+
+                    Then("A transaction is opened per attempt and nothing is published") {
+                        coVerify(exactly = 2) { persisting.transactionally(any<suspend () -> Any?>()) }
+                        coVerify(exactly = 0) { persisting.publish(any()) }
+                    }
+                }
+            }
+        }
     }
 })
+
+private fun uowEvent() = UowEvent(
+    id = UowEvent.Id.random(),
+    uowName = UowEvent.UowName("MockOfCreateDepartmentUow"),
+    principal = TestPrincipal,
+    modelEvents = listOf(),
+    idempotencyKey = null,
+    params = "{}",
+    occurredAt = ofEpochMilli(0),
+)
 
 private data class ExcPoint(
     val uowName: String?,

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/PersistingSpec.kt
@@ -204,7 +204,7 @@ class PersistingSpec : BehaviorSpec({
             supporstPipelining = pipelining
             history.clear()
             val persister: suspend (Boolean) -> Unit = { outOfOrder ->
-                persisting.persist(
+                val (uowEvent1, _) = persisting.persist(
                     uowName = "Hoba",
                     params = params,
                     principal = TestPrincipal,
@@ -228,7 +228,9 @@ class PersistingSpec : BehaviorSpec({
                     ),
                     now = clock.instant(),
                     uowSupportsOutOfOrderPersisting = outOfOrder,
+                    connectionMode = REQUIRE_NEW,
                 )
+                persisting.publish(uowEvent1)
             }
 
             When(
@@ -396,7 +398,7 @@ class PersistingSpec : BehaviorSpec({
                     "Principal persists noop changes with${if (supporstPipelining) "" else " no"} pipelining support" +
                         " and with${if (outOfOrder) "" else " no"} out of order persisting support",
                 ) {
-                    persisting.persist(
+                    val (uowEvent2, _) = persisting.persist(
                         uowName = "Hoba",
                         params = params,
                         principal = TestPrincipal,
@@ -425,7 +427,9 @@ class PersistingSpec : BehaviorSpec({
                         entityChanges = listOf(),
                         now = clock.instant(),
                         uowSupportsOutOfOrderPersisting = outOfOrder,
+                        connectionMode = REQUIRE_NEW,
                     )
+                    persisting.publish(uowEvent2)
 
                     And(
                         "Persisting history matching models and events from changes" +
@@ -460,7 +464,7 @@ class PersistingSpec : BehaviorSpec({
 
         history.clear()
         When("Principal persists single key deletion with out of order support") {
-            persisting.persist(
+            val (uowEvent3, _) = persisting.persist(
                 uowName = "DeleteByKey",
                 params = params,
                 principal = TestPrincipal,
@@ -470,7 +474,9 @@ class PersistingSpec : BehaviorSpec({
                 ),
                 now = clock.instant(),
                 uowSupportsOutOfOrderPersisting = true,
+                connectionMode = REQUIRE_NEW,
             )
+            persisting.publish(uowEvent3)
 
             Then("Persisting history contains key deletion step") {
                 history should {
@@ -492,7 +498,7 @@ class PersistingSpec : BehaviorSpec({
 
         history.clear()
         When("Principal persists multiple key deletions with out of order support") {
-            persisting.persist(
+            val (uowEvent4, _) = persisting.persist(
                 uowName = "BatchDeleteByKey",
                 params = params,
                 principal = TestPrincipal,
@@ -504,7 +510,9 @@ class PersistingSpec : BehaviorSpec({
                 ),
                 now = clock.instant(),
                 uowSupportsOutOfOrderPersisting = true,
+                connectionMode = REQUIRE_NEW,
             )
+            persisting.publish(uowEvent4)
 
             Then("Persisting history contains batched key deletion step") {
                 history should {
@@ -527,7 +535,7 @@ class PersistingSpec : BehaviorSpec({
         history.clear()
         When("Principal persists mixed entity add and key deletion") {
             val newTag = Tag.tag(keySubjectId, "new-tag", "value")
-            persisting.persist(
+            val (uowEvent5, _) = persisting.persist(
                 uowName = "MixedOperations",
                 params = params,
                 principal = TestPrincipal,
@@ -539,7 +547,9 @@ class PersistingSpec : BehaviorSpec({
                 ),
                 now = clock.instant(),
                 uowSupportsOutOfOrderPersisting = true,
+                connectionMode = REQUIRE_NEW,
             )
+            persisting.publish(uowEvent5)
 
             Then("Persisting history contains both add and key deletion steps") {
                 history should {
@@ -562,7 +572,7 @@ class PersistingSpec : BehaviorSpec({
 
         history.clear()
         When("Principal persists key deletion without out of order support") {
-            persisting.persist(
+            val (uowEvent6, _) = persisting.persist(
                 uowName = "SequentialDeleteByKey",
                 params = params,
                 principal = TestPrincipal,
@@ -573,7 +583,9 @@ class PersistingSpec : BehaviorSpec({
                 ),
                 now = clock.instant(),
                 uowSupportsOutOfOrderPersisting = false,
+                connectionMode = REQUIRE_NEW,
             )
+            persisting.publish(uowEvent6)
 
             Then("Persisting history contains individual key deletion steps") {
                 history should {

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
@@ -4,6 +4,8 @@ import com.razz.eva.domain.Bubaleh
 import com.razz.eva.domain.Department
 import com.razz.eva.domain.DepartmentId
 import com.razz.eva.domain.Employee
+import com.razz.eva.events.EventPublisher
+import com.razz.eva.events.UowEvent
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.config.DatabaseConfig
 import com.razz.eva.persistence.executor.QueryExecutor
@@ -26,6 +28,7 @@ import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.HireEmployeesUow
 import com.razz.eva.uow.Persisting
 import com.razz.eva.uow.UnitOfWorkExecutor
+import com.razz.eva.uow.WriteTxScope
 import com.razz.eva.uow.params.kotlinx.KotlinxParamsSerializer
 import com.razz.eva.uow.withFactory
 import io.opentelemetry.api.OpenTelemetry
@@ -104,7 +107,7 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
             CreateSoloDepartmentUow(executionContext, employeeRepo, departmentRepo)
         },
         HireEmployeesUow::class withFactory {
-            HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 0, true)
+            HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 0, true, WriteTxScope.FLUSH)
         },
     )
 
@@ -173,7 +176,7 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
     val uowxRetries = UnitOfWorkExecutor(
         factories = listOf(
             HireEmployeesUow::class withFactory {
-                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 1, false)
+                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 1, false, WriteTxScope.FLUSH)
             },
         ),
         persisting = persisting,
@@ -181,10 +184,49 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
         openTelemetry = openTelemetry,
     )
 
+    val publishedUowEvents = Collections.synchronizedList(mutableListOf<UowEvent>())
+
+    private val recordingEventPublisher = object : EventPublisher {
+        override suspend fun publish(uowEvent: UowEvent) {
+            publishedUowEvents += uowEvent
+        }
+    }
+
+    private val publishingPersisting = Persisting(
+        transactionManager = transactionManager,
+        modelRepos = modelRepos,
+        entityRepos = entityRepos,
+        eventRepository = eventRepository,
+        eventPublisher = recordingEventPublisher,
+        paramsSerializer = KotlinxParamsSerializer(),
+    )
+
+    val uowxFullUowScope = UnitOfWorkExecutor(
+        factories = listOf(
+            HireEmployeesUow::class withFactory {
+                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 1, true, WriteTxScope.FULL_UOW)
+            },
+        ),
+        persisting = publishingPersisting,
+        clock = clock,
+        openTelemetry = openTelemetry,
+    )
+
+    val uowxFullUowScopeNoRetries = UnitOfWorkExecutor(
+        factories = listOf(
+            HireEmployeesUow::class withFactory {
+                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 0, true, WriteTxScope.FULL_UOW)
+            },
+        ),
+        persisting = publishingPersisting,
+        clock = clock,
+        openTelemetry = openTelemetry,
+    )
+
     val uowxRollingBack = UnitOfWorkExecutor(
         factories = listOf(
             HireEmployeesUow::class withFactory {
-                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 0, false)
+                HireEmployeesUow(executionContext, departmentRepo, employeeRepo, 0, false, WriteTxScope.FLUSH)
             },
         ),
         persisting = Persisting(

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TxIdObservingUow.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TxIdObservingUow.kt
@@ -10,6 +10,7 @@ import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.TestPrincipal
 import com.razz.eva.uow.UnitOfWork
 import com.razz.eva.uow.WriteTxScope
+import com.razz.eva.uow.composable.UnitOfWork as ComposableUnitOfWork
 import com.razz.eva.uow.func.TxIdObservingUow.Params
 import com.razz.eva.uow.params.kotlinx.UowParams
 import kotlinx.serialization.Serializable
@@ -45,8 +46,8 @@ class TxIdObservingUow(
     )
 
     override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<ObservedTxIds> = changes {
-        val firstReadTxId = currentTxId()
-        val secondReadTxId = currentTxId()
+        val firstReadTxId = currentTxId(queryExecutor, dslContext)
+        val secondReadTxId = currentTxId(queryExecutor, dslContext)
         val department = newDepartment(
             name = params.departmentName,
             boss = EmployeeId(randomUUID()),
@@ -56,9 +57,69 @@ class TxIdObservingUow(
         add(department)
         ObservedTxIds(firstReadTxId, secondReadTxId, department.id())
     }
+}
 
-    private suspend fun currentTxId(): Long {
-        val query = dslContext.select(DSL.field("txid_current()", SQLDataType.BIGINT))
-        return queryExecutor.executeSelect(dslContext, query, DSL.table(query)).single().value1()
+/**
+ * Composable counterpart of [TxIdObservingUow]: the parent reads `txid_current()`, composes
+ * [TxIdObservingChildUow] (whose only job is to read `txid_current()` too) and adds one department.
+ * Lets a spec prove that a composed child's reads join the parent's FULL_UOW transaction.
+ */
+class ComposedTxIdObservingUow(
+    executionContext: ExecutionContext,
+    private val queryExecutor: QueryExecutor,
+    private val dslContext: DSLContext,
+    writeTxScope: WriteTxScope,
+) : ComposableUnitOfWork<TestPrincipal, ComposedTxIdObservingUow.Params, ComposedTxIdObservingUow.ObservedTxIds>(
+    executionContext,
+    Configuration(writeTxScope = writeTxScope),
+) {
+
+    @Serializable
+    data class Params(val departmentName: String) : UowParams<Params> {
+        override fun serialization() = serializer()
     }
+
+    data class ObservedTxIds(
+        val parentReadTxId: Long,
+        val childReadTxId: Long,
+        val departmentId: DepartmentId,
+    )
+
+    override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<ObservedTxIds> = changes {
+        val parentReadTxId = currentTxId(queryExecutor, dslContext)
+        val childReadTxId = execute(
+            { ctx -> TxIdObservingChildUow(ctx, queryExecutor, dslContext) },
+            principal,
+        ) {
+            TxIdObservingChildUow.Params(params.departmentName)
+        }
+        val department = newDepartment(
+            name = params.departmentName,
+            boss = EmployeeId(randomUUID()),
+            headcount = 1,
+            ration = SHAKSHOUKA,
+        )
+        add(department)
+        ObservedTxIds(parentReadTxId, childReadTxId, department.id())
+    }
+}
+
+class TxIdObservingChildUow(
+    executionContext: ExecutionContext,
+    private val queryExecutor: QueryExecutor,
+    private val dslContext: DSLContext,
+) : ComposableUnitOfWork<TestPrincipal, TxIdObservingChildUow.Params, Long>(executionContext) {
+
+    @Serializable
+    data class Params(val marker: String) : UowParams<Params> {
+        override fun serialization() = serializer()
+    }
+
+    override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<Long> =
+        noChanges(currentTxId(queryExecutor, dslContext))
+}
+
+private suspend fun currentTxId(queryExecutor: QueryExecutor, dslContext: DSLContext): Long {
+    val query = dslContext.select(DSL.field("txid_current()", SQLDataType.BIGINT))
+    return queryExecutor.executeSelect(dslContext, query, DSL.table(query)).single().value1()
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TxIdObservingUow.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TxIdObservingUow.kt
@@ -1,0 +1,64 @@
+package com.razz.eva.uow.func
+
+import com.razz.eva.domain.Department.Companion.newDepartment
+import com.razz.eva.domain.DepartmentId
+import com.razz.eva.domain.EmployeeId
+import com.razz.eva.domain.Ration.SHAKSHOUKA
+import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.eva.uow.Changes
+import com.razz.eva.uow.ExecutionContext
+import com.razz.eva.uow.TestPrincipal
+import com.razz.eva.uow.UnitOfWork
+import com.razz.eva.uow.WriteTxScope
+import com.razz.eva.uow.func.TxIdObservingUow.Params
+import com.razz.eva.uow.params.kotlinx.UowParams
+import kotlinx.serialization.Serializable
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import java.util.UUID.randomUUID
+
+/**
+ * Observes which transaction each of its perform reads runs in via `txid_current()` and adds one
+ * department, whose row `xmin` is the flush transaction id. Lets a spec prove whether perform reads
+ * and the flush share one transaction (FULL_UOW) or run in separate ones (FLUSH).
+ */
+class TxIdObservingUow(
+    executionContext: ExecutionContext,
+    private val queryExecutor: QueryExecutor,
+    private val dslContext: DSLContext,
+    writeTxScope: WriteTxScope,
+) : UnitOfWork<TestPrincipal, Params, TxIdObservingUow.ObservedTxIds>(
+    executionContext,
+    Configuration(writeTxScope = writeTxScope),
+) {
+
+    @Serializable
+    data class Params(val departmentName: String) : UowParams<Params> {
+        override fun serialization() = serializer()
+    }
+
+    data class ObservedTxIds(
+        val firstReadTxId: Long,
+        val secondReadTxId: Long,
+        val departmentId: DepartmentId,
+    )
+
+    override suspend fun tryPerform(principal: TestPrincipal, params: Params): Changes<ObservedTxIds> = changes {
+        val firstReadTxId = currentTxId()
+        val secondReadTxId = currentTxId()
+        val department = newDepartment(
+            name = params.departmentName,
+            boss = EmployeeId(randomUUID()),
+            headcount = 1,
+            ration = SHAKSHOUKA,
+        )
+        add(department)
+        ObservedTxIds(firstReadTxId, secondReadTxId, department.id())
+    }
+
+    private suspend fun currentTxId(): Long {
+        val query = dslContext.select(DSL.field("txid_current()", SQLDataType.BIGINT))
+        return queryExecutor.executeSelect(dslContext, query, DSL.table(query)).single().value1()
+    }
+}

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
@@ -75,6 +75,44 @@ class WriteTxScopeSpec : PersistenceBaseSpec({
         }
     }
 
+    Given("A composing uow observing the transaction id of its own read, a composed child read and its flush") {
+        fun composedTxIdObservingUowx(scope: WriteTxScope) = UnitOfWorkExecutor(
+            factories = listOf(
+                ComposedTxIdObservingUow::class withFactory {
+                    ComposedTxIdObservingUow(module.executionContext, module.queryExecutor, module.dslContext, scope)
+                },
+            ),
+            persisting = module.persisting,
+            clock = module.clock,
+            openTelemetry = module.openTelemetry,
+        )
+
+        When("Principal performs it FULL_UOW scoped") {
+            val observed = composedTxIdObservingUowx(WriteTxScope.FULL_UOW)
+                .execute(ComposedTxIdObservingUow::class, TestPrincipal) {
+                    ComposedTxIdObservingUow.Params("fulluow_composed_dep${nextInt(100000)}")
+                }
+
+            Then("Parent read, composed child read and the flush write share one transaction") {
+                observed.childReadTxId shouldBe observed.parentReadTxId
+                xminOf(observed.departmentId) shouldBe observed.parentReadTxId % xidMask
+            }
+        }
+
+        When("Principal performs it FLUSH scoped") {
+            val observed = composedTxIdObservingUowx(WriteTxScope.FLUSH)
+                .execute(ComposedTxIdObservingUow::class, TestPrincipal) {
+                    ComposedTxIdObservingUow.Params("flush_composed_dep${nextInt(100000)}")
+                }
+
+            Then("Parent read, composed child read and the flush write run in transactions of their own") {
+                observed.childReadTxId shouldNotBe observed.parentReadTxId
+                xminOf(observed.departmentId) shouldNotBe observed.parentReadTxId % xidMask
+                xminOf(observed.departmentId) shouldNotBe observed.childReadTxId % xidMask
+            }
+        }
+    }
+
     Given("A department exists") {
         val department = writableRepository.add(
             newDepartment(

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
@@ -7,10 +7,18 @@ import com.razz.eva.domain.Name
 import com.razz.eva.domain.Ration.SHAKSHOUKA
 import com.razz.eva.events.UowEvent.UowName
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
+import com.razz.eva.domain.DepartmentId
+import com.razz.eva.test.schema.Tables
 import com.razz.eva.uow.HireEmployeesUow
 import com.razz.eva.uow.TestPrincipal
+import com.razz.eva.uow.UnitOfWorkExecutor
+import com.razz.eva.uow.WriteTxScope
+import com.razz.eva.uow.withFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
 import kotlin.random.Random.Default.nextInt
 import java.util.UUID.randomUUID
 
@@ -19,6 +27,53 @@ class WriteTxScopeSpec : PersistenceBaseSpec({
     val departmentRepo = module.departmentRepo
     val employeeRepo = module.employeeRepo
     val writableRepository = module.writableRepository
+
+    fun txIdObservingUowx(scope: WriteTxScope) = UnitOfWorkExecutor(
+        factories = listOf(
+            TxIdObservingUow::class withFactory {
+                TxIdObservingUow(module.executionContext, module.queryExecutor, module.dslContext, scope)
+            },
+        ),
+        persisting = module.persisting,
+        clock = module.clock,
+        openTelemetry = module.openTelemetry,
+    )
+
+    // xmin holds the 32 bit id of the inserting transaction; txid_current() is epoch-extended
+    val xidMask = 4_294_967_296L
+    val xminOf: suspend (DepartmentId) -> Long = { departmentId ->
+        val query = module.dslContext
+            .select(DSL.field("xmin::text::bigint", SQLDataType.BIGINT))
+            .from(Tables.DEPARTMENTS)
+            .where(Tables.DEPARTMENTS.ID.eq(departmentId.id))
+        module.queryExecutor.executeSelect(module.dslContext, query, DSL.table(query)).single().value1()
+    }
+
+    Given("A uow observing the transaction id of its perform reads and its flush write") {
+
+        When("Principal performs it FULL_UOW scoped") {
+            val observed = txIdObservingUowx(WriteTxScope.FULL_UOW).execute(TxIdObservingUow::class, TestPrincipal) {
+                TxIdObservingUow.Params("fulluow_txid_dep${nextInt(100000)}")
+            }
+
+            Then("Both perform reads and the flush write share one transaction") {
+                observed.firstReadTxId shouldBe observed.secondReadTxId
+                xminOf(observed.departmentId) shouldBe observed.firstReadTxId % xidMask
+            }
+        }
+
+        When("Principal performs it FLUSH scoped") {
+            val observed = txIdObservingUowx(WriteTxScope.FLUSH).execute(TxIdObservingUow::class, TestPrincipal) {
+                TxIdObservingUow.Params("flush_txid_dep${nextInt(100000)}")
+            }
+
+            Then("Each perform read and the flush write run in transactions of their own") {
+                observed.firstReadTxId shouldNotBe observed.secondReadTxId
+                xminOf(observed.departmentId) shouldNotBe observed.firstReadTxId % xidMask
+                xminOf(observed.departmentId) shouldNotBe observed.secondReadTxId % xidMask
+            }
+        }
+    }
 
     Given("A department exists") {
         val department = writableRepository.add(

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/WriteTxScopeSpec.kt
@@ -1,0 +1,162 @@
+package com.razz.eva.uow.func
+
+import com.razz.eva.domain.Department.Companion.newDepartment
+import com.razz.eva.domain.Employee.Companion.newEmployee
+import com.razz.eva.domain.EmployeeId
+import com.razz.eva.domain.Name
+import com.razz.eva.domain.Ration.SHAKSHOUKA
+import com.razz.eva.events.UowEvent.UowName
+import com.razz.eva.persistence.PersistenceException.StaleRecordException
+import com.razz.eva.uow.HireEmployeesUow
+import com.razz.eva.uow.TestPrincipal
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlin.random.Random.Default.nextInt
+import java.util.UUID.randomUUID
+
+class WriteTxScopeSpec : PersistenceBaseSpec({
+
+    val departmentRepo = module.departmentRepo
+    val employeeRepo = module.employeeRepo
+    val writableRepository = module.writableRepository
+
+    Given("A department exists") {
+        val department = writableRepository.add(
+            newDepartment(
+                name = "fulluow_dep${nextInt(100000)}",
+                boss = EmployeeId(randomUUID()),
+                headcount = 1,
+                ration = SHAKSHOUKA,
+            ),
+        )
+
+        When("Principal performs a FULL_UOW scoped uow") {
+            module.publishedUowEvents.clear()
+            val hired = module.uowxFullUowScope.execute(HireEmployeesUow::class, TestPrincipal) {
+                HireEmployeesUow.Params(
+                    department.id(),
+                    listOf(Name("Elu", "Thingol"), Name("Finwe", "Noldoran")),
+                )
+            }
+
+            Then("Employees and department update are committed in one transaction") {
+                hired.size shouldBe 2
+                hired.forEach { employee ->
+                    employee.isPersisted() shouldBe true
+                    val persisted = requireNotNull(employeeRepo.find(employee.id()))
+                    persisted.departmentId shouldBe department.id()
+                    persisted.version() shouldBe employee.version()
+                }
+                departmentRepo.find(department.id())?.headcount shouldBe 3
+            }
+
+            Then("The uow event is published after the commit") {
+                module.publishedUowEvents.size shouldBe 1
+                module.publishedUowEvents.single().uowName shouldBe UowName("HireEmployeesUow")
+            }
+        }
+    }
+
+    Given("A department exists and will be updated concurrently before the flush") {
+        val department = writableRepository.add(
+            newDepartment(
+                name = "fulluow_stale_dep${nextInt(100000)}",
+                boss = EmployeeId(randomUUID()),
+                headcount = 1,
+                ration = SHAKSHOUKA,
+            ),
+        )
+        val employeeOutOfUow = newEmployee(
+            name = Name("Beren", "Erchamion${nextInt(100000)}"),
+            departmentId = department.id(),
+            email = "beren.erchamion${nextInt(100000)}@razz.com",
+            ration = SHAKSHOUKA,
+        )
+        var updatedOutOfUow = false
+        module.departmentPreUpdate.onPreUpdate(department.id()) {
+            if (!updatedOutOfUow) {
+                updatedOutOfUow = true
+                writableRepository.apply {
+                    add(employeeOutOfUow)
+                    update(
+                        checkNotNull(departmentRepo.find(department.id()))
+                            .addEmployee(employeeOutOfUow),
+                    )
+                }
+            }
+        }
+
+        When("Principal performs a FULL_UOW scoped uow with a retry budget") {
+            module.publishedUowEvents.clear()
+            val hired = module.uowxFullUowScope.execute(HireEmployeesUow::class, TestPrincipal) {
+                HireEmployeesUow.Params(
+                    department.id(),
+                    listOf(Name("Luthien", "Tinuviel")),
+                )
+            }
+
+            Then("First attempt rolls back on the stale department and the retry commits") {
+                hired.size shouldBe 1
+                requireNotNull(employeeRepo.find(hired.single().id())).departmentId shouldBe department.id()
+                departmentRepo.find(department.id())?.headcount shouldBe 3
+                employeeRepo.find(employeeOutOfUow.id())?.departmentId shouldBe department.id()
+            }
+
+            Then("Only the committed attempt is published") {
+                module.publishedUowEvents.size shouldBe 1
+            }
+        }
+    }
+
+    Given("Another department exists and will be updated concurrently before the flush") {
+        val department = writableRepository.add(
+            newDepartment(
+                name = "fulluow_noretry_dep${nextInt(100000)}",
+                boss = EmployeeId(randomUUID()),
+                headcount = 1,
+                ration = SHAKSHOUKA,
+            ),
+        )
+        val employeeOutOfUow = newEmployee(
+            name = Name("Turin", "Turambar${nextInt(100000)}"),
+            departmentId = department.id(),
+            email = "turin.turambar${nextInt(100000)}@razz.com",
+            ration = SHAKSHOUKA,
+        )
+        var updatedOutOfUow = false
+        module.departmentPreUpdate.onPreUpdate(department.id()) {
+            if (!updatedOutOfUow) {
+                updatedOutOfUow = true
+                writableRepository.apply {
+                    add(employeeOutOfUow)
+                    update(
+                        checkNotNull(departmentRepo.find(department.id()))
+                            .addEmployee(employeeOutOfUow),
+                    )
+                }
+            }
+        }
+
+        When("Principal performs a FULL_UOW scoped uow without retries") {
+            module.publishedUowEvents.clear()
+            val attempt = suspend {
+                module.uowxFullUowScopeNoRetries.execute(HireEmployeesUow::class, TestPrincipal) {
+                    HireEmployeesUow.Params(
+                        department.id(),
+                        listOf(Name("Nienor", "Niniel")),
+                    )
+                }
+            }
+
+            Then("The whole attempt rolls back leaving no partial state") {
+                shouldThrow<StaleRecordException> { attempt() }
+                departmentRepo.find(department.id())?.headcount shouldBe 2
+                employeeRepo.findByName(Name("Nienor", "Niniel")) shouldBe null
+            }
+
+            Then("Nothing is published for the rolled back attempt") {
+                module.publishedUowEvents.size shouldBe 0
+            }
+        }
+    }
+})

--- a/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/HireEmployeesUow.kt
+++ b/eva-uow/src/testFixtures/kotlin/com/razz/eva/uow/HireEmployeesUow.kt
@@ -21,9 +21,13 @@ class HireEmployeesUow(
     private val employeeRepo: EmployeeRepository,
     retries: Int,
     private val forceAdd: Boolean,
+    writeTxScope: WriteTxScope,
 ) : UnitOfWork<TestPrincipal, Params, List<Employee>>(
     executionContext,
-    Configuration(retry = StaleRecordFixedRetry(retries, Duration.ofMillis(100)))
+    Configuration(
+        retry = StaleRecordFixedRetry(retries, Duration.ofMillis(100)),
+        writeTxScope = writeTxScope,
+    )
 ) {
 
     @Serializable


### PR DESCRIPTION
Adds `WriteTxScope { FLUSH, FULL_UOW }` to `Configuration` (default FLUSH, current behaviour byte-for-byte: un-transacted primary reads, short write tx for the flush).

`FULL_UOW` wraps tryPerform and the flush in one transaction on a single pooled connection. Reads join it through the connection in the coroutine context (including composed uows and lazy `ModelParam.model()` re-queries), cutting pool/semaphore acquisitions from one per read plus one for the flush down to one per attempt. Under READ COMMITTED this is semantically a no-op for a uow whose perform only reads; it is an operational trade: the connection and open transaction are held for the whole attempt. Intended for fast, database-bound uows only -- never for uows that call gateways, do heavy CPU work or run parallel reads inside perform (those would serialise on the one connection). Candidates get picked from the `uow.perform.timer` stats introduced in 0.31.0.

Notable restructure: `eventPublisher.publish` moved out of `Persisting.persist` to the executor, after the attempt's transaction commits. Joining an outer transaction would otherwise publish before the outer commit; as a side effect a throwing publisher can no longer be retried into a double commit.

Retry behaviour: each attempt opens a fresh transaction; a stale flush rolls back the whole attempt including perform-side effects. Under FLUSH, tryPerform stays outside the retry catch as before. Functional coverage in `WriteTxScopeSpec`: FULL_UOW success, stale conflict with retry, and no-retry rollback leaving no partial state and publishing nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)