### PR TITLE
Count perform phase connection acquisitions per uow

### DIFF
--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/ConnectionAcquisitionCounter.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/ConnectionAcquisitionCounter.kt
@@ -1,0 +1,25 @@
+package com.razz.eva.persistence
+
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Counts pooled connection acquisitions made while this element is present in the coroutine context.
+ * The unit of work executor installs one around tryPerform, so the recorded value is the number of
+ * connections the perform phase acquired: one per read in the default flush scope, zero in the
+ * full unit of work scope where reads join the attempt's already-open transaction.
+ */
+class ConnectionAcquisitionCounter : CoroutineContext.Element {
+
+    private val acquisitions = AtomicLong(0)
+
+    fun increment() {
+        acquisitions.incrementAndGet()
+    }
+
+    fun count(): Long = acquisitions.get()
+
+    override val key: CoroutineContext.Key<*> = Key
+
+    companion object Key : CoroutineContext.Key<ConnectionAcquisitionCounter>
+}

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
@@ -17,6 +17,7 @@ abstract class TransactionManager<C>(
                 var newConn: C? = null
                 try {
                     newConn = connectionProvider(currentCoroutineContext()).acquire()
+                    currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
                     block(newConn)
                 } finally {
                     newConn?.let { connectionProvider(currentCoroutineContext()).release(it) }
@@ -36,6 +37,7 @@ abstract class TransactionManager<C>(
                 var newConn: C? = null
                 try {
                     newConn = primaryProvider.acquire()
+                    currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
                     val ctx = wrapConnection(newConn)
                     withContext(ctx) {
                         try {

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -2,6 +2,7 @@ package com.razz.eva.uow
 
 import com.razz.eva.domain.Model
 import com.razz.eva.domain.Principal
+import com.razz.eva.persistence.ConnectionAcquisitionCounter
 import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.razz.eva.tracing.getEvaMeter
@@ -106,8 +107,8 @@ class UnitOfWorkExecutor(
                     uowSpan.setAttribute(UOW_NAME, name)
                 }
                 val constructedParams = params(InstantiationContext.External(currentAttempt))
-                val changes = timed(performTimer, name) {
-                    withContext(PrimaryConnectionRequiredFlag + uowSpan.asContextElement()) {
+                val changes = instrumentedPerform(name) { acquisitions ->
+                    withContext(PrimaryConnectionRequiredFlag + acquisitions + uowSpan.asContextElement()) {
                         performingSpan(name).use {
                             uow.tryPerform(principal, constructedParams)
                         }
@@ -337,6 +338,15 @@ class UnitOfWorkExecutor(
 
     private val persistTimer = createTimer("uow.persist.timer", "Unit of work persist phase execution time")
 
+    // unit stays a curly-brace annotation so the prometheus exporter does not suffix the metric name
+    private val performAcquisitionsMetric = openTelemetry.getEvaMeter()
+        .histogramBuilder("uow.perform.connection.acquisitions")
+        .setDescription("Pooled connection acquisitions during unit of work perform phase")
+        .setUnit("{acquisition}")
+        .ofLongs()
+        .setExplicitBucketBoundariesAdvice(ACQUISITION_BUCKET_BOUNDARIES)
+        .build()
+
     private fun createTimer(name: String, description: String) = openTelemetry.getEvaMeter()
         .histogramBuilder(name)
         .setDescription(description)
@@ -346,6 +356,18 @@ class UnitOfWorkExecutor(
         // observation lands in +Inf and quantiles saturate; advise boundaries covering 0.5ms .. 60s
         .setExplicitBucketBoundariesAdvice(TIMER_BUCKET_BOUNDARIES_NANOS)
         .build()
+
+    private inline fun <T> instrumentedPerform(uowName: String, block: (ConnectionAcquisitionCounter) -> T): T {
+        val acquisitions = ConnectionAcquisitionCounter()
+        val start = System.nanoTime()
+        return try {
+            block(acquisitions)
+        } finally {
+            val attributes = Attributes.of(AttributeKey.stringKey(UOW_NAME), uowName)
+            performTimer.record(System.nanoTime() - start, attributes)
+            performAcquisitionsMetric.record(acquisitions.count(), attributes)
+        }
+    }
 
     private inline fun <T> timed(timer: LongHistogram, uowName: String, block: () -> T): T {
         val start = System.nanoTime()
@@ -382,5 +404,6 @@ class UnitOfWorkExecutor(
             30_000_000_000L,
             60_000_000_000L, // 60s
         )
+        private val ACQUISITION_BUCKET_BOUNDARIES = listOf(0L, 1L, 2L, 3L, 5L, 8L, 13L, 21L, 50L)
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/UnitOfWorkExecutorSpec.kt
@@ -121,6 +121,45 @@ class UnitOfWorkExecutorSpec : BehaviorSpec({
             }
         }
 
+        And("Factory which acquires connections during perform") {
+            val txnManager = WithCtxConnectionTransactionManager()
+            @Suppress("UNCHECKED_CAST") val factories = listOf(
+                (DummyUow::class as KClass<DummyUow<String>>) withFactory {
+                    object : DummyUow<String>(it) {
+                        override suspend fun tryPerform(
+                            principal: TestPrincipal,
+                            params: Params,
+                        ): Changes<String> {
+                            txnManager.withConnection { }
+                            txnManager.withConnection { }
+                            return noChanges("acquired")
+                        }
+                    }
+                },
+            )
+            val metricReader = InMemoryMetricReader.create()
+            val uowx = UnitOfWorkExecutor(
+                factories,
+                Persisting(
+                    transactionManager = txnManager,
+                    modelRepos = ModelRepos(),
+                    entityRepos = EntityRepos(),
+                    eventRepository = DummyEventRepository(),
+                    paramsSerializer = KotlinxParamsSerializer(),
+                ),
+                clock,
+                OpenTelemetryTestConfiguration.create(metricReader = metricReader),
+            )
+
+            When("UnitOfWorkExecutor executes Uow") {
+                uowx.execute((DummyUow::class as KClass<DummyUow<String>>), TestPrincipal) { DummyUow.Params }
+
+                Then("Both perform reads are counted, the flush acquisition outside perform is not") {
+                    metricReader.acquisitionsSum() shouldBe 2
+                }
+            }
+        }
+
         var tick = ofEpochMilli(0)
         val crawlingInstant = InstantSource {
             val tock = tick.plusMillis(1)
@@ -980,6 +1019,13 @@ private data class ExcPoint(
     val willRetry: Boolean?,
     val value: Long,
 )
+
+private fun InMemoryMetricReader.acquisitionsSum(): Long =
+    collectAllMetrics()
+        .filter { it.name == "uow.perform.connection.acquisitions" }
+        .flatMap { metric -> metric.histogramData.points }
+        .sumOf { it.sum }
+        .toLong()
 
 private fun InMemoryMetricReader.timerBoundaries(timerName: String): List<Double> =
     collectAllMetrics()


### PR DESCRIPTION
Adds `uow.perform.connection.acquisitions` (LongHistogram, `uow.name` attribute): the number of pooled connections a unit of work's perform phase acquires, i.e. one per read today. A `ConnectionAcquisitionCounter` coroutine context element is installed by the executor around `tryPerform` and incremented at the two `TransactionManager` acquire sites, covering both JDBC and Vert.x. The unit is the annotation `{acquisition}` so the prometheus exporter does not suffix the name.

Together with `uow.perform.timer` (0.31.0) this makes WriteTxScope FULL_UOW candidate selection (razz-team/eva#289) fully metric-driven: candidates need at least 2 acquisitions per perform, and a flipped uow's value drops to zero since its reads join the attempt's transaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)