### PR TITLE
Measure blocking jdbc dispatcher wait per operation

### DIFF
--- a/eva-persistence-jdbc/build.gradle.kts
+++ b/eva-persistence-jdbc/build.gradle.kts
@@ -14,4 +14,6 @@ dependencies {
 
     implementation(libs.postgres)
     implementation(libs.jooq)
+
+    testImplementation(libs.opentelemetry.sdk.testing)
 }

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManager.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManager.kt
@@ -4,6 +4,10 @@ import com.razz.eva.persistence.ConnectionMode
 import com.razz.eva.persistence.ConnectionProvider
 import com.razz.eva.persistence.ConnectionWrapper
 import com.razz.eva.persistence.TransactionManager
+import com.razz.eva.tracing.getEvaMeter
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -14,18 +18,40 @@ class JdbcTransactionManager(
     primaryProvider: ConnectionProvider<Connection>,
     replicaProvider: ConnectionProvider<Connection>,
     private val blockingJdbcContext: CoroutineDispatcher = Dispatchers.IO,
+    openTelemetry: OpenTelemetry? = null,
 ) : TransactionManager<Connection>(primaryProvider, replicaProvider) {
 
+    // otel default boundaries are millisecond-oriented; dispatch waits sit in the micro to
+    // millisecond range, so advise boundaries covering 10us .. 1s
+    private val dispatchWaitMetric = openTelemetry?.getEvaMeter()
+        ?.histogramBuilder("jdbc.dispatch.wait")
+        ?.setDescription("Wait between scheduling onto the blocking jdbc dispatcher and execution start")
+        ?.setUnit("ns")
+        ?.ofLongs()
+        ?.setExplicitBucketBoundariesAdvice(DISPATCH_WAIT_BUCKET_BOUNDARIES_NANOS)
+        ?.build()
+
     override suspend fun <R> withConnection(block: suspend (Connection) -> R): R {
+        val scheduledAt = System.nanoTime()
         return withContext(blockingJdbcContext) {
+            recordDispatchWait(scheduledAt, WITH_CONNECTION)
             super.withConnection(block)
         }
     }
 
     override suspend fun <R> inTransaction(mode: ConnectionMode, block: suspend (Connection) -> R): R {
+        val scheduledAt = System.nanoTime()
         return withContext(blockingJdbcContext) {
+            recordDispatchWait(scheduledAt, IN_TRANSACTION)
             super.inTransaction(mode, block)
         }
+    }
+
+    private fun recordDispatchWait(scheduledAt: Long, op: String) {
+        dispatchWaitMetric?.record(
+            System.nanoTime() - scheduledAt,
+            Attributes.of(AttributeKey.stringKey(OP), op),
+        )
     }
 
     override fun wrapConnection(newConn: Connection): ConnectionWrapper<Connection> =
@@ -35,4 +61,23 @@ class JdbcTransactionManager(
         coroutineContext[JdbcConnectionElement]?.connection
 
     override fun supportsPipelining(): Boolean = false
+
+    companion object {
+        private const val OP = "op"
+        private const val WITH_CONNECTION = "with_connection"
+        private const val IN_TRANSACTION = "in_transaction"
+        private val DISPATCH_WAIT_BUCKET_BOUNDARIES_NANOS = listOf(
+            10_000L, // 10us
+            50_000L,
+            100_000L,
+            500_000L,
+            1_000_000L, // 1ms
+            5_000_000L,
+            10_000_000L, // 10ms
+            50_000_000L,
+            100_000_000L, // 100ms
+            500_000_000L,
+            1_000_000_000L, // 1s
+        )
+    }
 }

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManagerSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManagerSpec.kt
@@ -6,7 +6,12 @@ import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import io.mockk.clearMocks
 import io.mockk.confirmVerified
 import io.mockk.every
@@ -488,6 +493,34 @@ class JdbcTransactionManagerSpec : BehaviorSpec({
                     confirmVerified(replicaPool)
                     confirmVerified(connection)
                 }
+            }
+        }
+    }
+
+    Given("Jdbc transaction manager with otel metrics") {
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val pool = mockk<HikariDataSource>()
+        val provider = HikariPoolConnectionProvider(pool)
+        val transactionManager = JdbcTransactionManager(provider, provider, Dispatchers.IO, openTelemetry)
+        val connection = mockk<Connection>(relaxed = true)
+        every { connection.autoCommit } returns true
+        every { pool.connection } returns connection
+
+        When("Principal runs withConnection and inTransaction") {
+            transactionManager.withConnection { }
+            transactionManager.inTransaction(REQUIRE_NEW) { }
+
+            Then("Dispatch wait is recorded per op with nanosecond bucket boundaries") {
+                val points = metricReader.collectAllMetrics()
+                    .filter { it.name == "jdbc.dispatch.wait" }
+                    .flatMap { metric -> metric.histogramData.points }
+                points.map { it.attributes.get(AttributeKey.stringKey("op")) }.toSet() shouldBe
+                    setOf("with_connection", "in_transaction")
+                points.forEach { point -> point.count shouldBe 1 }
+                points.first().boundaries shouldContain 1_000_000.0
             }
         }
     }


### PR DESCRIPTION
Adds `jdbc.dispatch.wait` (LongHistogram, ns, attribute `op` = `with_connection` | `in_transaction`) to `JdbcTransactionManager`: the gap between scheduling work onto `blockingJdbcContext` and execution start. The manager gains an optional `openTelemetry` constructor parameter (default null keeps it silent), matching `DataSourceConnectionProvider`.

Motivation: after flipping uows to `FULL_UOW` in production, two of four flipped uows halved their p99 perform on their flip day while pool acquire-wait sat at microseconds - suggesting the latency lived in per-read dispatch queueing on the fixed-size blocking dispatcher, which no existing metric observes. Under `FLUSH` every read dispatches separately; under `FULL_UOW` one dispatch covers the attempt. This histogram lets a consumer confirm or refute that: business-hours tails on `op=with_connection` line up with the hypothesis, a flat distribution refutes it.

Bucket advice covers 10us to 1s (dispatch waits are micro to millisecond scale; otel defaults would saturate). A note for consumers: wire `openTelemetry` into `JdbcTransactionManager` at construction to enable it.

Implementation detail: the recording happens inline in each override rather than through a shared suspend wrapper - wrapping the `super` call in an extra lambda layer sent mockk `spyk` in the executor spec into infinite recursion via the virtualised super-accessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)