### PR TITLE
Classify connection failures as PersistenceException.ConnectionException

### DIFF
--- a/eva-persistence-jdbc/build.gradle.kts
+++ b/eva-persistence-jdbc/build.gradle.kts
@@ -16,4 +16,5 @@ dependencies {
     implementation(libs.jooq)
 
     testImplementation(libs.opentelemetry.sdk.testing)
+    testImplementation(testFixtures(project(eva.eva_persistence)))
 }

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -114,13 +114,11 @@ class JdbcQueryExecutor(
                 tableName = table.name,
                 constraintName = extractUniqueConstraintName(dae, table)?.name,
             )
-
             dae.sqlStateClass() == C23_INTEGRITY_CONSTRAINT_VIOLATION -> ModelRecordConstraintViolationException(
                 modelId = modelId,
                 tableName = table.name,
                 constraintName = extractConstraintName(dae)?.name,
             )
-
             // https://www.postgresql.org/message-id/flat/CANbGkDhq9gZnEouo2PZHP3HGMAJKk7fZf3eU3Q8g46Y-1uGZ-w%40mail.gmail.com#e5de345d77abe0184e394f0701bb8bc5
             //  According to the thread above, transaction error with message message
             //  "tuple to be locked was already moved to another partition due to concurrent update"
@@ -129,9 +127,7 @@ class JdbcQueryExecutor(
             //  This should not cause transaction rollback in T0 due to serialisation error,
             //  rather we should fail due to version mismatch (stale record).
             dae.sqlStateClass() == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
-
             dae.sqlStateClass() == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
-
             else -> ModelPersistingGenericException(modelId, ex)
         }
     }

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -11,6 +11,7 @@ import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationE
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
+import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
 import com.razz.eva.tracing.QueryTracingListenerProvider
 import io.opentelemetry.api.OpenTelemetry
@@ -127,15 +128,18 @@ class JdbcQueryExecutor(
             //  This should not cause transaction rollback in T0 due to serialisation error,
             //  rather we should fail due to version mismatch (stale record).
             dae.sqlStateClass() == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
-            dae.sqlStateClass() == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
+            dae.connectionUnavailable() -> ConnectionException(ex)
             else -> ModelPersistingGenericException(modelId, ex)
         }
     }
 
     override fun extractConnectionException(ex: Exception): ConnectionException? {
         val dae = ex as? DataAccessException ?: return null
-        return if (dae.sqlStateClass() == C08_CONNECTION_EXCEPTION) ConnectionException(ex) else null
+        return if (dae.connectionUnavailable()) ConnectionException(ex) else null
     }
+
+    private fun DataAccessException.connectionUnavailable(): Boolean =
+        sqlStateClass() == C08_CONNECTION_EXCEPTION || sqlState() in PG_CONNECTION_UNAVAILABLE
 
     private fun DSLContext.using(connection: Connection): DSLContext {
         val configWithConnection = configuration()

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -3,6 +3,7 @@ package com.razz.eva.persistence.jdbc.executor
 import com.razz.eva.domain.ModelId
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.PersistenceException
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelPersistingGenericException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
@@ -23,6 +24,7 @@ import org.jooq.Select
 import org.jooq.StoreQuery
 import org.jooq.Table
 import org.jooq.exception.DataAccessException
+import org.jooq.exception.SQLStateClass.C08_CONNECTION_EXCEPTION
 import org.jooq.exception.SQLStateClass.C23_INTEGRITY_CONSTRAINT_VIOLATION
 import org.jooq.exception.SQLStateClass.C40_TRANSACTION_ROLLBACK
 import org.jooq.impl.DSL
@@ -128,8 +130,15 @@ class JdbcQueryExecutor(
             //  rather we should fail due to version mismatch (stale record).
             dae.sqlStateClass() == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
 
+            dae.sqlStateClass() == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
+
             else -> ModelPersistingGenericException(modelId, ex)
         }
+    }
+
+    override fun extractConnectionException(ex: Exception): ConnectionException? {
+        val dae = ex as? DataAccessException ?: return null
+        return if (dae.sqlStateClass() == C08_CONNECTION_EXCEPTION) ConnectionException(ex) else null
     }
 
     private fun DSLContext.using(connection: Connection): DSLContext {

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManagerSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManagerSpec.kt
@@ -2,12 +2,14 @@ package com.razz.eva.persistence.jdbc
 
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PrimaryConnectionRequiredFlag
 import com.zaxxer.hikari.HikariDataSource
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
@@ -18,12 +20,14 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 import java.sql.Connection
+import java.sql.SQLTransientConnectionException
 
 class JdbcTransactionManagerSpec : BehaviorSpec({
 
@@ -521,6 +525,44 @@ class JdbcTransactionManagerSpec : BehaviorSpec({
                     setOf("with_connection", "in_transaction")
                 points.forEach { point -> point.count shouldBe 1 }
                 points.first().boundaries shouldContain 1_000_000.0
+            }
+        }
+    }
+
+    Given("Jdbc transaction manager with a pool failing to provide connections") {
+        val failingPool = mockk<HikariDataSource>()
+        val failingProvider = HikariPoolConnectionProvider(failingPool)
+        val txManager = JdbcTransactionManager(failingProvider, failingProvider)
+
+        When("Principal calls withConnection and connection acquisition fails") {
+            every { failingPool.connection } throws SQLTransientConnectionException("pool exhausted")
+
+            Then("ConnectionException with the original cause is thrown") {
+                val ex = shouldThrow<ConnectionException> {
+                    txManager.withConnection { TODO("NEVER HAPPENS") }
+                }
+                ex.cause.shouldBeTypeOf<SQLTransientConnectionException>()
+            }
+        }
+
+        When("Principal starts new transaction and connection acquisition fails") {
+            every { failingPool.connection } throws SQLTransientConnectionException("pool exhausted")
+
+            Then("ConnectionException with the original cause is thrown") {
+                val ex = shouldThrow<ConnectionException> {
+                    txManager.inTransaction(REQUIRE_NEW) { _ -> TODO("NEVER HAPPENS") }
+                }
+                ex.cause.shouldBeTypeOf<SQLTransientConnectionException>()
+            }
+        }
+
+        When("Connection acquisition is cancelled") {
+            every { failingPool.connection } throws CancellationException("cancelled on acquire")
+
+            Then("CancellationException propagates unwrapped") {
+                shouldThrow<CancellationException> {
+                    txManager.withConnection { TODO("NEVER HAPPENS") }
+                }
             }
         }
     }

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcConnectionFailureWireSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcConnectionFailureWireSpec.kt
@@ -1,0 +1,70 @@
+package com.razz.eva.persistence.jdbc.executor
+
+import com.razz.eva.persistence.FakePostgres
+import com.razz.eva.persistence.PersistenceException.ConnectionException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.mockk
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.exception.DataAccessException
+import org.jooq.impl.DSL
+import org.postgresql.util.PSQLException
+import java.sql.DriverManager
+
+class JdbcConnectionFailureWireSpec : BehaviorSpec({
+
+    Given("Jdbc query executor and a fake postgres failing the first statement with admin shutdown") {
+        val executor = JdbcQueryExecutor(mockk(relaxed = true))
+
+        When("A real driver connection runs a statement") {
+            val extracted = FakePostgres.failingOnFirstStatement("57P01").use { fakePostgres ->
+                val thrown = shouldThrow<DataAccessException> {
+                    DriverManager.getConnection(fakePostgres.jdbcUrl()).use { connection ->
+                        DSL.using(connection, POSTGRES).fetch("select 1")
+                    }
+                }
+                executor.extractConnectionException(thrown)
+            }
+
+            Then("The wire-decoded failure classifies as ConnectionException") {
+                extracted.shouldBeTypeOf<ConnectionException>()
+            }
+        }
+    }
+
+    Given("Jdbc query executor and a fake postgres dying on the first statement without a message") {
+        val executor = JdbcQueryExecutor(mockk(relaxed = true))
+
+        When("A real driver connection runs a statement") {
+            val extracted = FakePostgres.closingOnFirstStatement().use { fakePostgres ->
+                val thrown = shouldThrow<DataAccessException> {
+                    DriverManager.getConnection(fakePostgres.jdbcUrl()).use { connection ->
+                        DSL.using(connection, POSTGRES).fetch("select 1")
+                    }
+                }
+                executor.extractConnectionException(thrown)
+            }
+
+            Then("The code-absent socket death classifies as ConnectionException") {
+                extracted.shouldBeTypeOf<ConnectionException>()
+            }
+        }
+    }
+
+    Given("A fake postgres refusing connections with too many connections") {
+
+        When("A real driver connects") {
+            val thrown = FakePostgres.failingAtStartup("53300").use { fakePostgres ->
+                shouldThrow<PSQLException> {
+                    DriverManager.getConnection(fakePostgres.jdbcUrl())
+                }
+            }
+
+            Then("The driver surfaces the sql state from the wire") {
+                thrown.sqlState shouldBe "53300"
+            }
+        }
+    }
+})

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
@@ -1,11 +1,13 @@
 package com.razz.eva.persistence.jdbc.executor
 
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.jdbc.JdbcConnectionElement
 import com.razz.eva.persistence.jdbc.JdbcConnectionProvider
 import com.razz.eva.persistence.jdbc.JdbcTransactionManager
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -13,9 +15,11 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.opentelemetry.api.OpenTelemetry.noop
 import java.sql.Connection
+import java.sql.SQLException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.jooq.SQLDialect.POSTGRES
+import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL
 
 class JdbcQueryExecutorSpec : BehaviorSpec({
@@ -178,6 +182,34 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
                         connectionProvider.release(connection)
                     }
                 }
+            }
+        }
+    }
+
+    Given("Jdbc query executor extracting connection exceptions") {
+        val executor = JdbcQueryExecutor(mockk(relaxed = true))
+
+        When("DataAccessException of connection class is extracted") {
+            val connectionLoss = DataAccessException("read failed", SQLException("connection reset", "08006"))
+            val extracted = executor.extractConnectionException(connectionLoss)
+
+            Then("ConnectionException with the original cause is returned") {
+                extracted.shouldBeTypeOf<ConnectionException>()
+                extracted.cause shouldBe connectionLoss
+            }
+        }
+
+        When("DataAccessException of constraint class is extracted") {
+            val uniqueViolation = DataAccessException("duplicate", SQLException("duplicate key", "23505"))
+
+            Then("Nothing is extracted") {
+                executor.extractConnectionException(uniqueViolation) shouldBe null
+            }
+        }
+
+        When("Exception which is not a DataAccessException is extracted") {
+            Then("Nothing is extracted") {
+                executor.extractConnectionException(IllegalStateException("not jooq")) shouldBe null
             }
         }
     }

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
@@ -199,6 +199,32 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
             }
         }
 
+        When("DataAccessException of admin shutdown is extracted") {
+            val adminShutdown = DataAccessException("terminating", SQLException("shutting down", "57P01"))
+            val extracted = executor.extractConnectionException(adminShutdown)
+
+            Then("ConnectionException with the original cause is returned") {
+                extracted.shouldBeTypeOf<ConnectionException>()
+                extracted.cause shouldBe adminShutdown
+            }
+        }
+
+        When("DataAccessException of too many connections is extracted") {
+            val tooManyConnections = DataAccessException("refused", SQLException("too many clients", "53300"))
+
+            Then("ConnectionException is returned") {
+                executor.extractConnectionException(tooManyConnections).shouldBeTypeOf<ConnectionException>()
+            }
+        }
+
+        When("DataAccessException of query cancel is extracted") {
+            val queryCanceled = DataAccessException("canceled", SQLException("statement timeout", "57014"))
+
+            Then("Nothing is extracted because the connection survives a statement timeout") {
+                executor.extractConnectionException(queryCanceled) shouldBe null
+            }
+        }
+
         When("DataAccessException of constraint class is extracted") {
             val uniqueViolation = DataAccessException("duplicate", SQLException("duplicate key", "23505"))
 

--- a/eva-persistence-vertx/build.gradle.kts
+++ b/eva-persistence-vertx/build.gradle.kts
@@ -18,4 +18,6 @@ dependencies {
     implementation(libs.vertx.kotlin.coroutines)
     implementation(libs.jooq)
     implementation(libs.jooq.postgres)
+
+    testImplementation(testFixtures(project(eva.eva_persistence)))
 }

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -3,6 +3,7 @@ package com.razz.eva.persistence.vertx.executor
 import com.razz.eva.domain.ModelId
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.PersistenceException
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelPersistingGenericException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
@@ -31,6 +32,7 @@ import org.jooq.Select
 import org.jooq.StoreQuery
 import org.jooq.Table
 import org.jooq.exception.SQLStateClass
+import org.jooq.exception.SQLStateClass.C08_CONNECTION_EXCEPTION
 import org.jooq.exception.SQLStateClass.C23_INTEGRITY_CONSTRAINT_VIOLATION
 import org.jooq.exception.SQLStateClass.C40_TRANSACTION_ROLLBACK
 import org.jooq.impl.SQLDataType
@@ -185,8 +187,15 @@ class VertxQueryExecutor(
             //  rather we should fail due to version mismatch (stale record).
             pge.sqlStateClass == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
 
+            pge.sqlStateClass == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
+
             else -> ModelPersistingGenericException(modelId, ex)
         }
+    }
+
+    override fun extractConnectionException(ex: Exception): ConnectionException? {
+        val pge = ex as? PgException ?: return null
+        return if (pge.sqlStateClass == C08_CONNECTION_EXCEPTION) ConnectionException(ex) else null
     }
 }
 

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -17,6 +17,7 @@ import io.vertx.core.json.Json
 import io.vertx.kotlin.coroutines.coAwait
 import io.vertx.pgclient.PgConnection
 import io.vertx.pgclient.PgException
+import io.vertx.sqlclient.ClosedConnectionException
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.RowSet
 import io.vertx.sqlclient.SqlResult
@@ -38,6 +39,7 @@ import org.jooq.exception.SQLStateClass.C23_INTEGRITY_CONSTRAINT_VIOLATION
 import org.jooq.exception.SQLStateClass.C40_TRANSACTION_ROLLBACK
 import org.jooq.impl.SQLDataType
 import org.jooq.postgres.extensions.types.Inet
+import java.io.IOException
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -165,17 +167,18 @@ class VertxQueryExecutor(
     }
 
     override fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException? {
-        val pge = ex as? PgException ?: return null
         return when {
-            pge.sqlState == PG_UNIQUE_VIOLATION -> UniqueModelRecordViolationException(
+            ex.connectionDead() -> ConnectionException(ex)
+            ex !is PgException -> null
+            ex.sqlState == PG_UNIQUE_VIOLATION -> UniqueModelRecordViolationException(
                 modelId = modelId,
                 tableName = table.name,
-                constraintName = pge.constraint,
+                constraintName = ex.constraint,
             )
-            pge.sqlStateClass == C23_INTEGRITY_CONSTRAINT_VIOLATION -> ModelRecordConstraintViolationException(
+            ex.sqlStateClass == C23_INTEGRITY_CONSTRAINT_VIOLATION -> ModelRecordConstraintViolationException(
                 modelId = modelId,
                 tableName = table.name,
-                constraintName = pge.constraint,
+                constraintName = ex.constraint,
             )
             // https://www.postgresql.org/message-id/flat/CANbGkDhq9gZnEouo2PZHP3HGMAJKk7fZf3eU3Q8g46Y-1uGZ-w%40mail.gmail.com#e5de345d77abe0184e394f0701bb8bc5
             //  According to the thread above, transaction error with message message
@@ -184,16 +187,21 @@ class VertxQueryExecutor(
             //  and concurrent transaction T0 is trying to update the same record.
             //  This should not cause transaction rollback in T0 due to serialisation error,
             //  rather we should fail due to version mismatch (stale record).
-            pge.sqlStateClass == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
-            pge.connectionUnavailable() -> ConnectionException(ex)
+            ex.sqlStateClass == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
+            ex.connectionUnavailable() -> ConnectionException(ex)
             else -> ModelPersistingGenericException(modelId, ex)
         }
     }
 
-    override fun extractConnectionException(ex: Exception): ConnectionException? {
-        val pge = ex as? PgException ?: return null
-        return if (pge.connectionUnavailable()) ConnectionException(ex) else null
+    override fun extractConnectionException(ex: Exception): ConnectionException? = when {
+        ex.connectionDead() -> ConnectionException(ex)
+        ex is PgException && ex.connectionUnavailable() -> ConnectionException(ex)
+        else -> null
     }
+
+    // the vertx client has no wrapping layer: a socket death surfaces either as its
+    // ClosedConnectionException or as a raw io exception, both without a sql state to match on
+    private fun Exception.connectionDead(): Boolean = this is ClosedConnectionException || this is IOException
 
     private fun PgException.connectionUnavailable(): Boolean =
         sqlStateClass == C08_CONNECTION_EXCEPTION || sqlState in PG_CONNECTION_UNAVAILABLE

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -11,6 +11,7 @@ import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationE
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
+import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
 import io.vertx.core.json.Json
 import io.vertx.kotlin.coroutines.coAwait
@@ -184,15 +185,18 @@ class VertxQueryExecutor(
             //  This should not cause transaction rollback in T0 due to serialisation error,
             //  rather we should fail due to version mismatch (stale record).
             pge.sqlStateClass == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
-            pge.sqlStateClass == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
+            pge.connectionUnavailable() -> ConnectionException(ex)
             else -> ModelPersistingGenericException(modelId, ex)
         }
     }
 
     override fun extractConnectionException(ex: Exception): ConnectionException? {
         val pge = ex as? PgException ?: return null
-        return if (pge.sqlStateClass == C08_CONNECTION_EXCEPTION) ConnectionException(ex) else null
+        return if (pge.connectionUnavailable()) ConnectionException(ex) else null
     }
+
+    private fun PgException.connectionUnavailable(): Boolean =
+        sqlStateClass == C08_CONNECTION_EXCEPTION || sqlState in PG_CONNECTION_UNAVAILABLE
 }
 
 private val PgException.sqlStateClass get() = SQLStateClass.fromCode(sqlState)

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -165,14 +165,12 @@ class VertxQueryExecutor(
 
     override fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException? {
         val pge = ex as? PgException ?: return null
-
         return when {
             pge.sqlState == PG_UNIQUE_VIOLATION -> UniqueModelRecordViolationException(
                 modelId = modelId,
                 tableName = table.name,
                 constraintName = pge.constraint,
             )
-
             pge.sqlStateClass == C23_INTEGRITY_CONSTRAINT_VIOLATION -> ModelRecordConstraintViolationException(
                 modelId = modelId,
                 tableName = table.name,
@@ -186,9 +184,7 @@ class VertxQueryExecutor(
             //  This should not cause transaction rollback in T0 due to serialisation error,
             //  rather we should fail due to version mismatch (stale record).
             pge.sqlStateClass == C40_TRANSACTION_ROLLBACK -> StaleRecordException(modelId, table.name)
-
             pge.sqlStateClass == C08_CONNECTION_EXCEPTION -> ConnectionException(ex)
-
             else -> ModelPersistingGenericException(modelId, ex)
         }
     }

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxConnectionFailureWireSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxConnectionFailureWireSpec.kt
@@ -1,0 +1,88 @@
+package com.razz.eva.persistence.vertx.executor
+
+import com.razz.eva.persistence.FakePostgres
+import com.razz.eva.persistence.PersistenceException.ConnectionException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.types.shouldBeTypeOf
+import io.mockk.mockk
+import io.vertx.core.Vertx
+import io.vertx.kotlin.coroutines.coAwait
+import io.vertx.pgclient.PgConnectOptions
+import io.vertx.pgclient.PgConnection
+
+class VertxConnectionFailureWireSpec : BehaviorSpec({
+
+    val executor = VertxQueryExecutor(mockk(relaxed = true))
+
+    suspend fun failingStatement(fakePostgres: FakePostgres): Exception {
+        val vertx = Vertx.vertx()
+        return try {
+            val options = PgConnectOptions().apply {
+                host = "localhost"
+                port = fakePostgres.port
+                database = "fake"
+                user = "fake"
+                password = "fake"
+            }
+            val connection = PgConnection.connect(vertx, options).coAwait()
+            shouldThrow<Exception> {
+                connection.query("select 1").execute().coAwait()
+            }
+        } finally {
+            vertx.close().coAwait()
+        }
+    }
+
+    Given("Vertx query executor and a fake postgres failing the first statement with admin shutdown") {
+        // the client decodes the FATAL, tears the connection down and may fail the pending query with
+        // either the decoded error or its closed-connection exception: classification must hold for both
+        When("A real client connection runs a statement") {
+            val thrown = FakePostgres.failingOnFirstStatement("57P01").use { fakePostgres ->
+                failingStatement(fakePostgres)
+            }
+
+            Then("The wire-decoded failure classifies as ConnectionException") {
+                executor.extractConnectionException(thrown).shouldBeTypeOf<ConnectionException>()
+            }
+        }
+    }
+
+    Given("Vertx query executor and a fake postgres dying on the first statement without a message") {
+        When("A real client connection runs a statement") {
+            val thrown = FakePostgres.closingOnFirstStatement().use { fakePostgres ->
+                failingStatement(fakePostgres)
+            }
+
+            Then("The code-absent socket death classifies as ConnectionException") {
+                executor.extractConnectionException(thrown).shouldBeTypeOf<ConnectionException>()
+            }
+        }
+    }
+
+    Given("A fake postgres refusing connections with too many connections") {
+        When("A real client connects") {
+            val thrown = FakePostgres.failingAtStartup("53300").use { fakePostgres ->
+                val vertx = Vertx.vertx()
+                try {
+                    val options = PgConnectOptions().apply {
+                        host = "localhost"
+                        port = fakePostgres.port
+                        database = "fake"
+                        user = "fake"
+                        password = "fake"
+                    }
+                    shouldThrow<Exception> {
+                        PgConnection.connect(vertx, options).coAwait()
+                    }
+                } finally {
+                    vertx.close().coAwait()
+                }
+            }
+
+            Then("The refusal classifies as ConnectionException") {
+                executor.extractConnectionException(thrown).shouldBeTypeOf<ConnectionException>()
+            }
+        }
+    }
+})

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorSpec.kt
@@ -235,6 +235,32 @@ class VertxQueryExecutorSpec : BehaviorSpec({
             }
         }
 
+        When("PgException of admin shutdown is extracted") {
+            val adminShutdown = PgException("terminating connection", "FATAL", "57P01", null)
+
+            Then("ConnectionException is returned") {
+                executor.extractConnectionException(adminShutdown)
+                    .shouldBeTypeOf<PersistenceException.ConnectionException>()
+            }
+        }
+
+        When("PgException of too many connections is extracted") {
+            val tooManyConnections = PgException("too many clients", "FATAL", "53300", null)
+
+            Then("ConnectionException is returned") {
+                executor.extractConnectionException(tooManyConnections)
+                    .shouldBeTypeOf<PersistenceException.ConnectionException>()
+            }
+        }
+
+        When("PgException of query cancel is extracted") {
+            val queryCanceled = PgException("canceling statement", "ERROR", "57014", null)
+
+            Then("Nothing is extracted because the connection survives a statement timeout") {
+                executor.extractConnectionException(queryCanceled) shouldBe null
+            }
+        }
+
         When("PgException of constraint class is extracted") {
             val uniqueViolation = PgException("duplicate key", "ERROR", "23505", null)
 

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorSpec.kt
@@ -1,11 +1,13 @@
 package com.razz.eva.persistence.vertx.executor
 
+import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.vertx.PgPoolConnectionProvider
 import com.razz.eva.persistence.vertx.VertxConnectionElement
 import com.razz.eva.persistence.vertx.VertxTransactionManager
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -14,6 +16,7 @@ import io.mockk.mockk
 import io.mockk.spyk
 import io.vertx.core.Future.succeededFuture
 import io.vertx.pgclient.PgConnection
+import io.vertx.pgclient.PgException
 import io.vertx.sqlclient.PreparedQuery
 import io.vertx.sqlclient.Row
 import io.vertx.sqlclient.RowSet
@@ -215,6 +218,28 @@ class VertxQueryExecutorSpec : BehaviorSpec({
                         connectionProvider.acquire()
                     }
                 }
+            }
+        }
+    }
+
+    Given("Vertx query executor extracting connection exceptions") {
+        val executor = VertxQueryExecutor(mockk(relaxed = true))
+
+        When("PgException of connection class is extracted") {
+            val connectionLoss = PgException("connection failure", "FATAL", "08006", null)
+            val extracted = executor.extractConnectionException(connectionLoss)
+
+            Then("ConnectionException with the original cause is returned") {
+                extracted.shouldBeTypeOf<PersistenceException.ConnectionException>()
+                extracted.cause shouldBe connectionLoss
+            }
+        }
+
+        When("PgException of constraint class is extracted") {
+            val uniqueViolation = PgException("duplicate key", "ERROR", "23505", null)
+
+            Then("Nothing is extracted") {
+                executor.extractConnectionException(uniqueViolation) shouldBe null
             }
         }
     }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/ConnectionAcquisitionCounter.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/ConnectionAcquisitionCounter.kt
@@ -8,6 +8,10 @@ import kotlin.coroutines.CoroutineContext
  * The unit of work executor installs one around tryPerform, so the recorded value is the number of
  * connections the perform phase acquired: one per read in the default flush scope, zero in the
  * full unit of work scope where reads join the attempt's already-open transaction.
+ *
+ * The zero is structural, not an absence of work: the full-scope attempt's single connection is
+ * acquired before this element is installed, so it is deliberately never counted. Consumers rely on
+ * the drop to zero as the verification signal that a scope flip took effect.
  */
 class ConnectionAcquisitionCounter : CoroutineContext.Element {
 

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/PersistenceException.kt
@@ -78,6 +78,10 @@ sealed class PersistenceException(message: String) : RuntimeException(message) {
         override val cause: Throwable,
     ) : PersistenceException("Persisting failed")
 
+    class ConnectionException(
+        override val cause: Throwable,
+    ) : PersistenceException("Database connection failed")
+
     class EventPayloadTooLargeException(
         val modelId: ModelId<*>,
         val modelEventId: UUID,

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
@@ -2,6 +2,8 @@ package com.razz.eva.persistence
 
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.ConnectionMode.REQUIRE_NEW
+import com.razz.eva.persistence.PersistenceException.ConnectionException
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.currentCoroutineContext
@@ -16,7 +18,7 @@ abstract class TransactionManager<C>(
             null -> {
                 var newConn: C? = null
                 try {
-                    newConn = connectionProvider(currentCoroutineContext()).acquire()
+                    newConn = acquire(connectionProvider(currentCoroutineContext()))
                     currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
                     block(newConn)
                 } finally {
@@ -36,7 +38,7 @@ abstract class TransactionManager<C>(
                 check(mode == REQUIRE_NEW) { "Required existing connection but no existing connection was found" }
                 var newConn: C? = null
                 try {
-                    newConn = primaryProvider.acquire()
+                    newConn = acquire(primaryProvider)
                     currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
                     val ctx = wrapConnection(newConn)
                     withContext(ctx) {
@@ -63,6 +65,14 @@ abstract class TransactionManager<C>(
                 block(existingConn)
             }
         }
+    }
+
+    private suspend fun acquire(provider: ConnectionProvider<C>): C = try {
+        provider.acquire()
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        throw ConnectionException(e)
     }
 
     private fun connectionProvider(coroutineContext: CoroutineContext) =

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
@@ -69,10 +69,10 @@ abstract class TransactionManager<C>(
 
     private suspend fun acquire(provider: ConnectionProvider<C>): C = try {
         provider.acquire()
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        throw ConnectionException(e)
+    } catch (ex: CancellationException) {
+        throw ex
+    } catch (ex: Exception) {
+        throw ConnectionException(ex)
     }
 
     private fun connectionProvider(coroutineContext: CoroutineContext) =

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -34,6 +34,8 @@ interface QueryExecutor {
 
     fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException?
 
+    fun extractConnectionException(ex: Exception): PersistenceException.ConnectionException?
+
     @JvmInline
     value class Constraint(val name: String?)
 }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/postgres/PgHelpers.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/postgres/PgHelpers.kt
@@ -2,4 +2,17 @@ package com.razz.eva.persistence.postgres
 
 object PgHelpers {
     const val PG_UNIQUE_VIOLATION = "23505"
+
+    /**
+     * Sql states outside class 08 which still mean the connection is unavailable: the three states
+     * a postgres restart produces plus a full connection slot table. Deliberately not the whole
+     * class 57: `57014 query_canceled` is a statement timeout or a user cancel, the connection
+     * survives it and a retry on a healthy connection would misclassify it.
+     */
+    val PG_CONNECTION_UNAVAILABLE = setOf(
+        "57P01", // admin_shutdown
+        "57P02", // crash_shutdown
+        "57P03", // cannot_connect_now
+        "53300", // too_many_connections
+    )
 }

--- a/eva-persistence/src/testFixtures/kotlin/com/razz/eva/persistence/FakePostgres.kt
+++ b/eva-persistence/src/testFixtures/kotlin/com/razz/eva/persistence/FakePostgres.kt
@@ -1,0 +1,146 @@
+package com.razz.eva.persistence
+
+import java.io.DataInputStream
+import java.io.DataOutputStream
+import java.net.ServerSocket
+import java.net.Socket
+import kotlin.concurrent.thread
+
+/**
+ * A fake postgres speaking just enough of the v3 wire protocol to fail on purpose. It either refuses
+ * at startup or completes the handshake and answers the first statement with a byte-correct FATAL
+ * ErrorResponse carrying the given sql state. Tests drive the real driver decode path for states which
+ * are operationally awkward to produce, for example `53300` without exhausting a slot table or `57P02`
+ * without crashing anything.
+ */
+class FakePostgres private constructor(
+    private val mode: Mode,
+    private val sqlState: String,
+) : AutoCloseable {
+
+    private enum class Mode { STARTUP_ERROR, STATEMENT_ERROR, STATEMENT_CLOSE }
+
+    private val server = ServerSocket(0)
+
+    init {
+        thread(isDaemon = true, name = "fake-postgres-${server.localPort}") { acceptLoop() }
+    }
+
+    val port: Int get() = server.localPort
+
+    fun jdbcUrl(): String =
+        "jdbc:postgresql://localhost:$port/fake?sslmode=disable&assumeMinServerVersion=9.4&user=fake"
+
+    private fun acceptLoop() {
+        while (!server.isClosed) {
+            val socket = try {
+                server.accept()
+            } catch (ex: Exception) {
+                return
+            }
+            try {
+                socket.use { serve(it) }
+            } catch (ex: Exception) {
+                // the driver under test closed mid-conversation, nothing to serve
+            }
+        }
+    }
+
+    private fun serve(socket: Socket) {
+        val input = DataInputStream(socket.getInputStream())
+        val output = DataOutputStream(socket.getOutputStream())
+        readStartup(input, output)
+        when (mode) {
+            Mode.STARTUP_ERROR -> writeErrorResponse(output)
+            Mode.STATEMENT_ERROR -> {
+                writeHandshake(output)
+                input.readByte()
+                // close right after the error: pgjdbc surfaces the recorded FATAL on EOF, and it
+                // deadlocks on a still-open socket waiting for a ReadyForQuery which never comes
+                writeErrorResponse(output)
+            }
+            Mode.STATEMENT_CLOSE -> {
+                writeHandshake(output)
+                input.readByte()
+            }
+        }
+    }
+
+    private fun readStartup(input: DataInputStream, output: DataOutputStream) {
+        val length = input.readInt()
+        val code = input.readInt()
+        if (code == SSL_REQUEST) {
+            output.writeByte(SSL_DENIED)
+            output.flush()
+            val startupLength = input.readInt()
+            input.skipNBytes((startupLength - Int.SIZE_BYTES).toLong())
+        } else {
+            input.skipNBytes((length - 2 * Int.SIZE_BYTES).toLong())
+        }
+    }
+
+    private fun writeHandshake(output: DataOutputStream) {
+        output.writeByte('R'.code)
+        output.writeInt(AUTH_OK_LENGTH)
+        output.writeInt(0)
+        parameterStatus(output, "server_version", "14.5")
+        parameterStatus(output, "client_encoding", "UTF8")
+        parameterStatus(output, "standard_conforming_strings", "on")
+        parameterStatus(output, "integer_datetimes", "on")
+        parameterStatus(output, "TimeZone", "UTC")
+        output.writeByte('K'.code)
+        output.writeInt(BACKEND_KEY_LENGTH)
+        output.writeInt(BACKEND_PID)
+        output.writeInt(BACKEND_SECRET)
+        output.writeByte('Z'.code)
+        output.writeInt(READY_LENGTH)
+        output.writeByte('I'.code)
+        output.flush()
+    }
+
+    private fun parameterStatus(output: DataOutputStream, key: String, value: String) {
+        val payload = key.toByteArray() + NUL + value.toByteArray() + NUL
+        output.writeByte('S'.code)
+        output.writeInt(Int.SIZE_BYTES + payload.size)
+        output.write(payload)
+    }
+
+    private fun writeErrorResponse(output: DataOutputStream) {
+        val fields = field('S', "FATAL") +
+            field('V', "FATAL") +
+            field('C', sqlState) +
+            field('M', "fake postgres failure $sqlState") +
+            NUL
+        output.writeByte('E'.code)
+        output.writeInt(Int.SIZE_BYTES + fields.size)
+        output.write(fields)
+        output.flush()
+    }
+
+    private fun field(type: Char, value: String): ByteArray =
+        byteArrayOf(type.code.toByte()) + value.toByteArray() + NUL
+
+    override fun close() {
+        server.close()
+    }
+
+    companion object {
+        private const val SSL_REQUEST = 80877103
+        private const val SSL_DENIED = 'N'.code
+        private const val AUTH_OK_LENGTH = 8
+        private const val BACKEND_KEY_LENGTH = 12
+        private const val BACKEND_PID = 42
+        private const val BACKEND_SECRET = 42
+        private const val READY_LENGTH = 5
+        private val NUL = byteArrayOf(0)
+
+        fun failingAtStartup(sqlState: String): FakePostgres =
+            FakePostgres(Mode.STARTUP_ERROR, sqlState)
+
+        fun failingOnFirstStatement(sqlState: String): FakePostgres =
+            FakePostgres(Mode.STATEMENT_ERROR, sqlState)
+
+        fun closingOnFirstStatement(): FakePostgres =
+            FakePostgres(Mode.STATEMENT_CLOSE, "")
+    }
+}

--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/AbstractJooqRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/AbstractJooqRepository.kt
@@ -283,11 +283,15 @@ abstract class AbstractJooqRepository<ID, MID, M, ME, R>(
     }
 
     protected suspend fun <R : Record> allRecords(select: Select<R>): List<R> {
-        return queryExecutor.executeSelect(
-            dslContext = dslContext,
-            jooqQuery = select,
-            table = select.asTable(),
-        )
+        return try {
+            queryExecutor.executeSelect(
+                dslContext = dslContext,
+                jooqQuery = select,
+                table = select.asTable(),
+            )
+        } catch (ex: Exception) {
+            throw queryExecutor.extractConnectionException(ex) ?: ex
+        }
     }
 
     @Throws(JooqQueryException::class)

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
@@ -13,6 +13,8 @@ import com.razz.eva.domain.ModelState.PersistentState
 import com.razz.eva.domain.Ration
 import com.razz.eva.domain.Ration.BUBALEH
 import com.razz.eva.domain.Version.Companion.V1
+import com.razz.eva.domain.ModelId
+import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.StoreExecuted
 import com.razz.eva.persistence.executor.QueryExecutor
@@ -21,13 +23,21 @@ import com.razz.eva.test.schema.Tables.DEPARTMENTS
 import com.razz.eva.test.schema.enums.DepartmentsState
 import com.razz.eva.test.schema.tables.records.DepartmentsRecord
 import com.razz.jooq.converter.InstantConverter
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
+import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Record
 import org.jooq.SQLDialect.POSTGRES
+import org.jooq.Select
+import org.jooq.StoreQuery
+import org.jooq.Table
 import org.jooq.conf.ParamType.INLINED
+import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL
+import java.sql.SQLException
 import java.time.Instant.MAX
 import java.time.Instant.MIN
 import java.time.Instant.now
@@ -149,6 +159,53 @@ class JooqBaseRepositoryNegativeSpec : BehaviorSpec({
                         """.trim().replace(Regex("\\s+"), " ")
                     }
                 }
+            }
+        }
+    }
+
+    Given("JooqBaseRepository with queryExecutor failing selects with a connection error") {
+        val dslContext = DSL.using(POSTGRES)
+        val connectionLoss = DataAccessException("select failed", SQLException("connection reset", "08006"))
+        val queryExecutor = object : QueryExecutor {
+            override suspend fun <R : Record> executeSelect(
+                dslContext: DSLContext,
+                jooqQuery: Select<R>,
+                table: Table<R>,
+            ): List<R> = throw connectionLoss
+
+            override suspend fun <RIN : Record, ROUT : Record> executeStore(
+                dslContext: DSLContext,
+                jooqQuery: StoreQuery<RIN>,
+                table: Table<ROUT>,
+            ): List<ROUT> = TODO("NEVER HAPPENS")
+
+            override suspend fun <R : Record> executeQuery(
+                dslContext: DSLContext,
+                jooqQuery: DMLQuery<R>,
+            ): Int = TODO("NEVER HAPPENS")
+
+            override fun extractConstraintName(ex: Exception): QueryExecutor.Constraint? = null
+
+            override fun extractUniqueConstraintName(ex: Exception, table: Table<*>): QueryExecutor.Constraint? =
+                null
+
+            override fun extractModelException(
+                ex: Exception,
+                table: Table<*>,
+                modelId: ModelId<*>,
+            ): PersistenceException? = null
+
+            override fun extractConnectionException(ex: Exception): PersistenceException.ConnectionException? =
+                (ex as? DataAccessException)?.let { PersistenceException.ConnectionException(it) }
+        }
+        val repo = BadDepartmentRepository(queryExecutor, dslContext)
+
+        When("Principal finds department by id") {
+            Then("ConnectionException with the original cause is thrown") {
+                val ex = shouldThrow<PersistenceException.ConnectionException> {
+                    repo.find(randomDepartmentId())
+                }
+                ex.cause shouldBe connectionLoss
             }
         }
     }

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
@@ -75,6 +75,8 @@ class FakeMemorizingQueryExecutor(
 
     override fun extractModelException(ex: Exception, table: Table<*>, modelId: ModelId<*>): PersistenceException? = null
 
+    override fun extractConnectionException(ex: Exception): PersistenceException.ConnectionException? = null
+
     sealed class ExecutionStep {
 
         data class StoreExecuted(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
@@ -48,7 +48,12 @@ class ModelParam<MID : ModelId<out Comparable<*>>, M : Model<MID, *>> private co
         override val descriptor: SerialDescriptor = idSerializer.descriptor
         override fun serialize(encoder: Encoder, value: ModelParam<MID, *>) =
             idSerializer.serialize(encoder, value.id)
-        override fun deserialize(decoder: Decoder) = ModelParam(idSerializer.deserialize(decoder)) { TODO("lel") }
+        override fun deserialize(decoder: Decoder): ModelParam<MID, *> {
+            val id = idSerializer.deserialize(decoder)
+            return ModelParam(id) {
+                error("ModelParam [${id.stringValue()}] was deserialized and can not load its model")
+            }
+        }
     }
 
     companion object Factory {

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
@@ -1,6 +1,7 @@
 package com.razz.eva.uow
 
 import com.razz.eva.persistence.PersistenceException
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
@@ -49,6 +50,29 @@ abstract class Retry {
 
         companion object {
             val DEFAULT = UniqueViolationFixedRetry(1, ofMillis(100))
+        }
+    }
+
+    /**
+     * Retries [ConnectionException]: a connection acquisition failure or a connection loss
+     * witnessed by a statement. Opt-in only, deliberately without a DEFAULT: a connection lost
+     * after the flush was sent is ambiguous, the transaction may have committed. Use only for
+     * units whose replay is safe, that is effects are idempotent or guarded by an idempotency
+     * key or a unique constraint which turns the replay into a conflict.
+     */
+    data class ConnectionFixedRetry(
+        val attempts: Int,
+        val connectionDelay: Duration,
+    ) : Retry() {
+
+        override fun getNextDelay(currentAttempt: Int, ex: PersistenceException): Duration? {
+            return when {
+                attempts <= currentAttempt -> null
+                else -> when (ex) {
+                    is ConnectionException -> connectionDelay
+                    else -> null
+                }
+            }
         }
     }
 }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
@@ -7,6 +7,7 @@ import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
 import java.time.Duration
 import java.time.Duration.ofMillis
+import kotlin.random.Random
 
 abstract class Retry {
 
@@ -73,6 +74,42 @@ abstract class Retry {
                     else -> null
                 }
             }
+        }
+    }
+
+    /**
+     * Retries [ConnectionException] with capped exponential backoff and full jitter: attempt n
+     * sleeps a uniform random duration in [0, min(maxDelay, baseDelay * 2^n)]. Randomised delays
+     * spread a reconnect stampede which a fixed beat would re-synchronise, for example after
+     * `53300 too_many_connections`. Opt-in only and deliberately without a DEFAULT, same replay
+     * contract as [ConnectionFixedRetry].
+     */
+    data class ConnectionBackoffRetry(
+        val attempts: Int,
+        val baseDelay: Duration,
+        val maxDelay: Duration,
+    ) : Retry() {
+
+        override fun getNextDelay(currentAttempt: Int, ex: PersistenceException): Duration? {
+            return when {
+                attempts <= currentAttempt -> null
+                else -> when (ex) {
+                    is ConnectionException -> jittered(ceiling(currentAttempt))
+                    else -> null
+                }
+            }
+        }
+
+        internal fun ceiling(currentAttempt: Int): Duration {
+            val exponential = baseDelay.multipliedBy(1L shl currentAttempt.coerceAtMost(MAX_SHIFT))
+            return if (exponential < maxDelay) exponential else maxDelay
+        }
+
+        private fun jittered(ceiling: Duration): Duration =
+            Duration.ofNanos(Random.nextLong(0, ceiling.toNanos() + 1))
+
+        companion object {
+            private const val MAX_SHIFT = 30
         }
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
@@ -1,10 +1,21 @@
 package com.razz.eva.uow
 
 import com.razz.eva.domain.TestModel
+import com.razz.eva.domain.TestModelId
+import com.razz.eva.domain.TestModelId.Companion.randomTestModelId
 import com.razz.eva.uow.ModelParam.Factory.modelParam
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.NothingSerializer
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
 import java.time.Duration
+import java.util.UUID
 
 class ModelParamSpec : FunSpec({
 
@@ -78,6 +89,20 @@ class ModelParamSpec : FunSpec({
         val modelParam = InstantiationContext(0).modelParam(heldModel) { error("not used") }
         Thread.sleep(STALENESS_SLEEP_MILLIS)
         modelParam.model().param1 shouldBe heldModel.param1
+    }
+
+    test("Deserialized model param returns its id but refuses to load a model") {
+        val idSerializer = object : KSerializer<TestModelId> {
+            override val descriptor = String.serializer().descriptor
+            override fun serialize(encoder: Encoder, value: TestModelId) = encoder.encodeString(value.stringValue())
+            override fun deserialize(decoder: Decoder) = TestModelId(UUID.fromString(decoder.decodeString()))
+        }
+        val id = randomTestModelId()
+        val serializer = ModelParam.Serializer(idSerializer, NothingSerializer())
+        val modelParam = Json.decodeFromString(serializer, "\"${id.stringValue()}\"")
+        modelParam.id() shouldBe id
+        val ex = shouldThrow<IllegalStateException> { modelParam.model() }
+        ex.message shouldContain "was deserialized and can not load its model"
     }
 })
 

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
@@ -1,9 +1,11 @@
 package com.razz.eva.uow
 
 import com.razz.eva.domain.ModelId
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
+import com.razz.eva.uow.Retry.ConnectionFixedRetry
 import com.razz.eva.uow.Retry.StaleRecordFixedRetry
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -54,6 +56,34 @@ class RetrySpec : BehaviorSpec({
                 .getNextDelay(0, UniqueModelRecordViolationException(whateverModelId, "puk", "puk_idx"))
 
             Then("Next delay should be 0 millis") {
+                nextDelay shouldBe null
+            }
+        }
+    }
+
+    Given("ConnectionFixedRetry with 1 attempt") {
+        val retry = ConnectionFixedRetry(1, ofMillis(50))
+
+        When("Retry is polled for next delay for zeroth attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(0, ConnectionException(RuntimeException("pool exhausted")))
+
+            Then("Next delay should be 50 millis") {
+                nextDelay shouldBe ofMillis(50)
+            }
+        }
+
+        When("Retry is polled for next delay for first attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(1, ConnectionException(RuntimeException("pool exhausted")))
+
+            Then("Next delay should be null") {
+                nextDelay shouldBe null
+            }
+        }
+
+        When("Retry is polled for next delay for zeroth attempt and StaleRecordException") {
+            val nextDelay = retry.getNextDelay(0, StaleRecordException(whateverModelId, "cool_table"))
+
+            Then("Next delay should be null") {
                 nextDelay shouldBe null
             }
         }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
@@ -5,10 +5,13 @@ import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
+import com.razz.eva.uow.Retry.ConnectionBackoffRetry
 import com.razz.eva.uow.Retry.ConnectionFixedRetry
 import com.razz.eva.uow.Retry.StaleRecordFixedRetry
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.Duration
 import java.time.Duration.ofMillis
 import java.util.*
 import java.util.UUID.randomUUID
@@ -74,6 +77,46 @@ class RetrySpec : BehaviorSpec({
 
         When("Retry is polled for next delay for first attempt and ConnectionException") {
             val nextDelay = retry.getNextDelay(1, ConnectionException(RuntimeException("pool exhausted")))
+
+            Then("Next delay should be null") {
+                nextDelay shouldBe null
+            }
+        }
+
+        When("Retry is polled for next delay for zeroth attempt and StaleRecordException") {
+            val nextDelay = retry.getNextDelay(0, StaleRecordException(whateverModelId, "cool_table"))
+
+            Then("Next delay should be null") {
+                nextDelay shouldBe null
+            }
+        }
+    }
+
+    Given("ConnectionBackoffRetry with base 100 millis capped at 2 seconds") {
+        val retry = ConnectionBackoffRetry(10, ofMillis(100), ofMillis(2_000))
+
+        When("Ceiling is computed per attempt") {
+            Then("Ceiling doubles per attempt until the cap") {
+                retry.ceiling(0) shouldBe ofMillis(100)
+                retry.ceiling(1) shouldBe ofMillis(200)
+                retry.ceiling(4) shouldBe ofMillis(1_600)
+                retry.ceiling(5) shouldBe ofMillis(2_000)
+                retry.ceiling(50) shouldBe ofMillis(2_000)
+            }
+        }
+
+        When("Retry is polled for next delay for second attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(2, ConnectionException(RuntimeException("connection reset")))
+
+            Then("Next delay should be jittered within the attempt ceiling") {
+                nextDelay shouldNotBe null
+                (nextDelay!! >= Duration.ZERO) shouldBe true
+                (nextDelay <= ofMillis(400)) shouldBe true
+            }
+        }
+
+        When("Retry is polled for next delay for tenth attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(10, ConnectionException(RuntimeException("connection reset")))
 
             Then("Next delay should be null") {
                 nextDelay shouldBe null


### PR DESCRIPTION
Today a connection acquisition failure (pool timeout, connect refusal) surfaces as a raw `SQLException` and bypasses the whole failure machinery: it is not a `PersistenceException`, so it skips the FULL_UOW/flush conflict routing, `Retry.getNextDelay(attempt, ex: PersistenceException)` cannot see it, `onFailure` never runs, and the persistence exception counter does not count it. A mid-perform connection loss on a read has the same problem: the read path never wraps, so it propagates as a raw jOOQ `DataAccessException`.

Changes:

- New sealed subtype `PersistenceException.ConnectionException(cause)`.
- `TransactionManager` wraps both acquire sites: any acquisition failure is thrown as `ConnectionException`. `CancellationException` passes through unwrapped.
- New `QueryExecutor.extractConnectionException(ex)`: maps connection-unavailable sql states to `ConnectionException` - the whole class 08 plus the states a postgres restart produces (`57P01` admin_shutdown, `57P02` crash_shutdown, `57P03` cannot_connect_now) and `53300` too_many_connections. Deliberately not the whole class 57: `57014` query_canceled is a statement timeout, the connection survives it (pinned by tests). Implemented for both drivers, abstract on the interface so custom executors must decide (one-line override).
- `AbstractJooqRepository.allRecords` (the single read funnel behind `atMostOneRecord`/`firstRecord`/finders) rethrows through the extraction, so mid-statement connection loss on reads is typed.
- Both `extractModelException` impls gain the same connection-unavailable branch, so write-path connection loss stops hiding inside `ModelPersistingGenericException`.
- Two opt-in policies that can act on the new type: `Retry.ConnectionFixedRetry(attempts, connectionDelay)` and `Retry.ConnectionBackoffRetry(attempts, baseDelay, maxDelay)` - capped exponential backoff with full jitter, so a reconnect stampede (for example after `53300`) is spread instead of re-synchronised by a fixed beat. Deliberately without a `DEFAULT`: a connection lost after the flush statement was sent is ambiguous - the transaction may have committed. The kdoc states the contract: opt in only for units whose replay is safe (idempotent effects, or an idempotency key / unique constraint that turns a replay into a conflict).
- `ModelParam.Serializer.deserialize` no longer plants `TODO("lel")` as the model supplier: a deserialized param now throws a meaningful `IllegalStateException` if asked for its model.
- `ConnectionAcquisitionCounter` kdoc states that the FULL_UOW zero is structural (the attempt's connection is acquired before the counter is installed) and that consumers rely on the drop to zero as flip verification.

The classification is pinned through the wire, not only at the predicate: a FakePostgres test fixture (eva-persistence testFixtures) speaks just enough of the v3 protocol to complete a real handshake and then fail on purpose - FATAL with a chosen sql state at startup or on the first statement, or a bare socket close. Both drivers run real connections against it. The wire tests immediately caught a real gap: the vertx client surfaces socket death as ClosedConnectionException or a raw io exception, both without a sql state - the code-absent path is now mapped to ConnectionException on both extraction paths (pgjdbc wraps the same death as class 08 by itself).

Behaviour notes for consumers: exceptions seen on connection loss change type (raw `SQLException`/`DataAccessException` becomes `ConnectionException`); existing retry policies return null for it, so nothing is retried implicitly - retries happen only where a unit opts into `ConnectionFixedRetry`.