### PR TITLE
Guard the uow_events params column: size cap and Sensitive wrapper

### DIFF
--- a/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
+++ b/eva-repository/src/main/kotlin/com/razz/eva/repository/JooqEventRepository.kt
@@ -16,6 +16,9 @@ import com.razz.eva.repository.Fake.FakeModelEvent
 import com.razz.eva.serialization.json.JsonFormat.json
 import com.razz.eva.tracing.contextMap
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.Span
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
@@ -29,6 +32,7 @@ class JooqEventRepository(
     private val dslContext: DSLContext,
     private val openTelemetry: OpenTelemetry = OpenTelemetry.noop(),
     private val maxEventPayloadSize: Int = 1024 * 1024,
+    private val maxParamsSize: Int = 1024 * 1024,
 ) : EventRepository {
 
     override suspend fun warmup() {
@@ -87,7 +91,26 @@ class JooqEventRepository(
             modelEvents = uowEvent.modelEvents
                 .map { (id, _) -> id.uuidValue() }
                 .toTypedArray()
-            params = uowEvent.params
+            params = boundedParams(uowEvent)
+        }
+    }
+
+    private fun boundedParams(uowEvent: UowEvent): String {
+        val paramsSize = uowEvent.params.utf8SizeInBytes()
+        return if (paramsSize > maxParamsSize) {
+            // params is an audit aid: unlike a model event payload, an oversized value must not
+            // fail the unit of work, so the audit row keeps a self-describing marker instead
+            Span.current().addEvent(
+                "uow_events.params elided",
+                Attributes.of(
+                    AttributeKey.stringKey("uow.name"), uowEvent.uowName.toString(),
+                    AttributeKey.longKey("params.bytes"), paramsSize.toLong(),
+                    AttributeKey.longKey("params.max"), maxParamsSize.toLong(),
+                ),
+            )
+            """{"_params_elided":{"bytes":$paramsSize,"max":$maxParamsSize}}"""
+        } else {
+            uowEvent.params
         }
     }
 

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqEventRepositorySpec.kt
@@ -374,4 +374,89 @@ class JooqEventRepositorySpec : BehaviorSpec({
             }
         }
     }
+
+    Given("an sqlEventRepository with maxParamsSize set to 64 bytes") {
+        val dslContext = DSL.using(POSTGRES)
+        val queryExecutor = FakeMemorizingQueryExecutor()
+        val eventRepo = JooqEventRepository(queryExecutor, dslContext, maxParamsSize = 64)
+
+        When("inserting an uow event with params exceeding the maxParamsSize") {
+            val params = Params(1, "Nik".repeat(100), IdempotencyKey.random())
+            val serializedParams = json.encodeToString(params.serialization(), params)
+            val uowEvent = UowEvent(
+                id = UowEvent.Id(randomUUID()),
+                uowName = UowName("TestUow"),
+                principal = TestPrincipal,
+                modelEvents = listOf(),
+                idempotencyKey = params.idempotencyKey,
+                params = serializedParams,
+                occurredAt = now,
+            )
+            eventRepo.add(uowEvent)
+
+            Then("it should store a self-describing marker instead of the oversized params") {
+                val paramsSize = serializedParams.toByteArray(Charsets.UTF_8).size
+                queryExecutor.executionHistory shouldBe listOf(
+                    QueryExecuted(
+                        dslContext,
+                        dslContext.insertQuery(UOW_EVENTS)
+                            .also {
+                                it.setRecord(
+                                    UowEventsRecord().apply {
+                                        this.id = uowEvent.id.uuidValue()
+                                        this.name = uowEvent.uowName.toString()
+                                        this.idempotencyKey = uowEvent.idempotencyKey?.stringValue()
+                                        this.principalName = "TEST_PRINCIPAL"
+                                        this.principalId = "THIS_IS_SINGLETON"
+                                        this.occurredAt = now
+                                        this.modelEvents = arrayOf()
+                                        this.params = """{"_params_elided":{"bytes":$paramsSize,"max":64}}"""
+                                    },
+                                )
+                            },
+                    ),
+                )
+            }
+        }
+
+        When("inserting an uow event with params within the maxParamsSize") {
+            val queryExecutorUnderLimit = FakeMemorizingQueryExecutor()
+            val eventRepoUnderLimit = JooqEventRepository(queryExecutorUnderLimit, dslContext, maxParamsSize = 1024)
+            val params = Params(1, "Nik", IdempotencyKey.random())
+            val serializedParams = json.encodeToString(params.serialization(), params)
+            val uowEvent = UowEvent(
+                id = UowEvent.Id(randomUUID()),
+                uowName = UowName("TestUow"),
+                principal = TestPrincipal,
+                modelEvents = listOf(),
+                idempotencyKey = params.idempotencyKey,
+                params = serializedParams,
+                occurredAt = now,
+            )
+            eventRepoUnderLimit.add(uowEvent)
+
+            Then("it should store the params verbatim") {
+                queryExecutorUnderLimit.executionHistory shouldBe listOf(
+                    QueryExecuted(
+                        dslContext,
+                        dslContext.insertQuery(UOW_EVENTS)
+                            .also {
+                                it.setRecord(
+                                    UowEventsRecord().apply {
+                                        this.id = uowEvent.id.uuidValue()
+                                        this.name = uowEvent.uowName.toString()
+                                        this.idempotencyKey = uowEvent.idempotencyKey?.stringValue()
+                                        this.principalName = "TEST_PRINCIPAL"
+                                        this.principalId = "THIS_IS_SINGLETON"
+                                        this.occurredAt = now
+                                        this.modelEvents = arrayOf()
+                                        this.params = serializedParams
+                                    },
+                                )
+                            },
+                    ),
+                )
+            }
+        }
+    }
 })

--- a/eva-uow-params-kotlinx/src/main/kotlin/com/razz/eva/uow/params/kotlinx/Sensitive.kt
+++ b/eva-uow-params-kotlinx/src/main/kotlin/com/razz/eva/uow/params/kotlinx/Sensitive.kt
@@ -1,0 +1,39 @@
+package com.razz.eva.uow.params.kotlinx
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+
+/**
+ * Wraps a params field whose value must never reach the uow_events.params audit column.
+ * The serializer emits a redaction marker instead of the value, so "never stored" is a type
+ * instead of a comment. The wrapped value stays available in memory via [value] for the perform.
+ *
+ * For fields which are large rather than secret, prefer @Transient with a default value:
+ * a transient field is skipped entirely and the audit row stays smaller.
+ */
+@Serializable(with = Sensitive.Serializer::class)
+class Sensitive<T>(val value: T) {
+
+    override fun toString(): String = REDACTED
+
+    class Serializer<T>(
+        @Suppress("unused") private val valueSerializer: KSerializer<T>,
+    ) : KSerializer<Sensitive<T>> {
+        override val descriptor: SerialDescriptor =
+            PrimitiveSerialDescriptor("com.razz.eva.uow.params.kotlinx.Sensitive", PrimitiveKind.STRING)
+
+        override fun serialize(encoder: Encoder, value: Sensitive<T>) = encoder.encodeString(REDACTED)
+
+        override fun deserialize(decoder: Decoder): Sensitive<T> =
+            error("Sensitive value was redacted at serialization and can not be deserialized")
+    }
+
+    companion object {
+        private const val REDACTED = "***"
+    }
+}

--- a/eva-uow-params-kotlinx/src/test/kotlin/com/razz/eva/uow/params/kotlinx/SensitiveSpec.kt
+++ b/eva-uow-params-kotlinx/src/test/kotlin/com/razz/eva/uow/params/kotlinx/SensitiveSpec.kt
@@ -1,0 +1,38 @@
+package com.razz.eva.uow.params.kotlinx
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+class SensitiveSpec : ShouldSpec({
+
+    should("serialize a sensitive field as a redaction marker") {
+        val params = LoginParams(user = "sergey", password = Sensitive("hunter2"))
+        val encoded = Json.encodeToString(LoginParams.serializer(), params)
+        encoded shouldBe """{"user":"sergey","password":"***"}"""
+    }
+
+    should("keep the wrapped value available in memory") {
+        Sensitive("hunter2").value shouldBe "hunter2"
+    }
+
+    should("redact toString") {
+        Sensitive("hunter2").toString() shouldBe "***"
+    }
+
+    should("refuse to deserialize a redacted value") {
+        val ex = shouldThrow<IllegalStateException> {
+            Json.decodeFromString(LoginParams.serializer(), """{"user":"sergey","password":"***"}""")
+        }
+        ex.message shouldContain "redacted"
+    }
+})
+
+@Serializable
+private data class LoginParams(
+    val user: String,
+    val password: Sensitive<String>,
+)


### PR DESCRIPTION
Params serialize verbatim into `uow_events.params` on every execution, and unlike model event payloads (`EventPayloadTooLargeException`) nothing bounds or redacts them. Two incidents motivate this: an unbounded chart-of-accounts list hoisted into params (fixed ad hoc with `@Transient`), and credential material serialized verbatim into audit rows.

Changes:

- `JooqEventRepository` gains `maxParamsSize` (default 1 MiB, same as the event payload cap). Over the cap the stored value is replaced with a self-describing marker `{"_params_elided":{"bytes":N,"max":M}}` and a span event is recorded. The unit of work is never failed: `uow_events` is an audit aid, so an audit problem must not kill good work - an oversized model event still fails hard as before.
- New `Sensitive<T>` wrapper in `eva-uow-params-kotlinx`: its serializer emits `"***"` instead of the value, so "never stored" becomes a type instead of a doc comment. The wrapped value stays available in memory for the perform. `toString` is redacted too. Deserialization throws: the value is gone by design.
- Convention, stated in the `Sensitive` kdoc: hoisted payloads which are large rather than secret should use `@Transient` with a default - the field is skipped entirely.

Kotlinx module only for now; a jackson twin can follow if any consumer needs it.