### PR TITLE
Add opt-in ConnectionFixedRetry for connection-transient failures

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Retry.kt
@@ -1,6 +1,7 @@
 package com.razz.eva.uow
 
 import com.razz.eva.persistence.PersistenceException
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
@@ -49,6 +50,29 @@ abstract class Retry {
 
         companion object {
             val DEFAULT = UniqueViolationFixedRetry(1, ofMillis(100))
+        }
+    }
+
+    /**
+     * Retries [ConnectionException]: a connection acquisition failure or a connection loss
+     * witnessed by a statement. Opt-in only, deliberately without a DEFAULT: a connection lost
+     * after the flush was sent is ambiguous, the transaction may have committed. Use only for
+     * units whose replay is safe, that is effects are idempotent or guarded by an idempotency
+     * key or a unique constraint which turns the replay into a conflict.
+     */
+    data class ConnectionFixedRetry(
+        val attempts: Int,
+        val connectionDelay: Duration,
+    ) : Retry() {
+
+        override fun getNextDelay(currentAttempt: Int, ex: PersistenceException): Duration? {
+            return when {
+                attempts <= currentAttempt -> null
+                else -> when (ex) {
+                    is ConnectionException -> connectionDelay
+                    else -> null
+                }
+            }
         }
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/RetrySpec.kt
@@ -1,9 +1,11 @@
 package com.razz.eva.uow
 
 import com.razz.eva.domain.ModelId
+import com.razz.eva.persistence.PersistenceException.ConnectionException
 import com.razz.eva.persistence.PersistenceException.ModelRecordConstraintViolationException
 import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
+import com.razz.eva.uow.Retry.ConnectionFixedRetry
 import com.razz.eva.uow.Retry.StaleRecordFixedRetry
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
@@ -54,6 +56,34 @@ class RetrySpec : BehaviorSpec({
                 .getNextDelay(0, UniqueModelRecordViolationException(whateverModelId, "puk", "puk_idx"))
 
             Then("Next delay should be 0 millis") {
+                nextDelay shouldBe null
+            }
+        }
+    }
+
+    Given("ConnectionFixedRetry with 1 attempt") {
+        val retry = ConnectionFixedRetry(1, ofMillis(50))
+
+        When("Retry is polled for next delay for zeroth attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(0, ConnectionException(RuntimeException("pool exhausted")))
+
+            Then("Next delay should be 50 millis") {
+                nextDelay shouldBe ofMillis(50)
+            }
+        }
+
+        When("Retry is polled for next delay for first attempt and ConnectionException") {
+            val nextDelay = retry.getNextDelay(1, ConnectionException(RuntimeException("pool exhausted")))
+
+            Then("Next delay should be null") {
+                nextDelay shouldBe null
+            }
+        }
+
+        When("Retry is polled for next delay for zeroth attempt and StaleRecordException") {
+            val nextDelay = retry.getNextDelay(0, StaleRecordException(whateverModelId, "cool_table"))
+
+            Then("Next delay should be null") {
                 nextDelay shouldBe null
             }
         }


### PR DESCRIPTION
Stacked on #292, which makes connection failures classifiable as `PersistenceException.ConnectionException`. This adds the policy that can act on them: `Retry.ConnectionFixedRetry(attempts, connectionDelay)`.

Deliberately without a `DEFAULT`: a connection lost after the flush statement was sent is ambiguous - the transaction may have committed. The kdoc states the contract: opt in only for units whose replay is safe (idempotent effects, or an idempotency key / unique constraint that turns a replay into a conflict).

Retarget to main after #292 merges.