### PR TITLE
Measure pool wait in DataSourceConnectionProvider

### DIFF
--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProvider.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProvider.kt
@@ -53,7 +53,6 @@ class DataSourceConnectionProvider(
         }) {
             semaphore.acquire()
         }
-
         // here are 2 issues to solve:
         // 1. if the current coroutine is cancelled and we don't have NonCancellable at all,
         //    the resulting connection will be discarded even if there is really nothing to cancel in this function

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProvider.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProvider.kt
@@ -1,5 +1,6 @@
 package com.razz.eva.persistence.jdbc
 
+import com.razz.eva.tracing.getEvaMeter
 import com.razz.eva.tracing.withSpan
 import io.opentelemetry.api.OpenTelemetry
 import kotlinx.coroutines.CoroutineDispatcher
@@ -23,9 +24,28 @@ class DataSourceConnectionProvider(
 
     private val semaphore = Semaphore(poolMaxSize)
 
+    // otel default boundaries are millisecond-oriented; pool waits sit in the micro to
+    // millisecond range, so advise boundaries covering 10us .. 1s
+    private val poolWaitMetric = openTelemetry?.getEvaMeter()
+        ?.histogramBuilder("jdbc.pool.wait")
+        ?.setDescription("Wait between requesting a pooled connection and holding it, semaphore included")
+        ?.setUnit("ns")
+        ?.ofLongs()
+        ?.setExplicitBucketBoundariesAdvice(POOL_WAIT_BUCKET_BOUNDARIES_NANOS)
+        ?.build()
+
     override suspend fun acquire(): Connection {
         coroutineContext.ensureActive() // fail-fast if current coroutine was cancelled before acquiring a connection
+        val requestedAt = System.nanoTime()
+        try {
+            return acquireThrottled()
+        } finally {
+            // recorded on failure paths too: a timed-out acquire is the most interesting wait
+            poolWaitMetric?.record(System.nanoTime() - requestedAt)
+        }
+    }
 
+    private suspend fun acquireThrottled(): Connection {
         // acquire a permit before acquiring a connection from the pool,
         // so we can be sure that won't just reserve a thread and wait for a connection to be available
         openTelemetry.withSpan(spanName = "semaphore-acquire", parameters = {
@@ -73,4 +93,20 @@ class DataSourceConnectionProvider(
         } finally {
             semaphore.release() // release the permit after closing the connection
         }
+
+    companion object {
+        private val POOL_WAIT_BUCKET_BOUNDARIES_NANOS = listOf(
+            10_000L, // 10us
+            50_000L,
+            100_000L,
+            500_000L,
+            1_000_000L, // 1ms
+            5_000_000L,
+            10_000_000L, // 10ms
+            50_000_000L,
+            100_000_000L, // 100ms
+            500_000_000L,
+            1_000_000_000L, // 1s
+        )
+    }
 }

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProviderSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/DataSourceConnectionProviderSpec.kt
@@ -2,11 +2,15 @@ package com.razz.eva.persistence.jdbc
 
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeSameInstanceAs
 import io.mockk.every
 import io.mockk.mockk
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -211,5 +215,22 @@ class DataSourceConnectionProviderSpec : ShouldSpec({
         withTimeout(Duration.ofMillis(200)) {
             runCatching { provider.acquire() }.exceptionOrNull()?.message shouldBe message
         }
+    }
+
+    should("record pool wait histogram when openTelemetry is provided") {
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val connection = mockk<Connection>(relaxed = true)
+        val pool = mockk<DataSource>()
+        every { pool.connection } returns connection
+        val provider = DataSourceConnectionProvider(pool, Dispatchers.IO, openTelemetry)
+        provider.acquire() shouldBeSameInstanceAs connection
+        val metric = metricReader.collectAllMetrics().single { it.name == "jdbc.pool.wait" }
+        val points = metric.histogramData.points
+        points shouldHaveSize 1
+        points.first().count shouldBe 1
+        points.first().boundaries shouldContain 1_000_000.0
     }
 })


### PR DESCRIPTION
Pool wait in `DataSourceConnectionProvider` is spans-only today (`semaphore-acquire` and `connection-acquire`), so it is sampled and invisible to dashboards. This adds a `jdbc.pool.wait` histogram (ns, 10us to 1s buckets, same style as `jdbc.dispatch.wait` from #291) covering the whole acquire: the eva-side semaphore plus the pool checkout. The wait is recorded on failure paths too, since a timed-out acquire is the most interesting wait.

Note the semaphore: `HikariPoolConnectionProvider` is a typealias of this class, and the semaphore throttles in front of Hikari, so its wait never shows in `hikaricp_connections_acquire`. This metric closes that blind spot. Opt-in: the histogram exists only when the `openTelemetry` constructor parameter is passed.