### PR TITLE
Add executeStore overload with explicit returning fields

### DIFF
--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -52,23 +52,19 @@ class JdbcQueryExecutor(
         dslContext: DSLContext,
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
+        returning: Collection<Field<*>>?,
     ): List<ROUT> {
-        jooqQuery.setReturning()
-        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            dslContext.using(connection).preparedQuery(jooqQuery, table)
-        }
-    }
-
-    override suspend fun <RIN : Record, ROUT : Record> executeStore(
-        dslContext: DSLContext,
-        jooqQuery: StoreQuery<RIN>,
-        table: Table<ROUT>,
-        returning: Collection<Field<*>>,
-    ): List<ROUT> {
-        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
-        jooqQuery.setReturning(returning)
-        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            dslContext.using(connection).preparedQuery(jooqQuery, returning).map { it.into(table) }
+        return if (returning == null) {
+            jooqQuery.setReturning()
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+                dslContext.using(connection).preparedQuery(jooqQuery, table)
+            }
+        } else {
+            require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+            jooqQuery.setReturning(returning)
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+                dslContext.using(connection).preparedQuery(jooqQuery, returning).map { it.into(table) }
+            }
         }
     }
 

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -22,6 +22,7 @@ import org.jooq.Field
 import org.jooq.Param
 import org.jooq.Query
 import org.jooq.Record
+import org.jooq.ResultQuery
 import org.jooq.Select
 import org.jooq.StoreQuery
 import org.jooq.Table
@@ -44,7 +45,7 @@ class JdbcQueryExecutor(
         table: Table<R>,
     ): List<R> {
         return transactionManager.withConnection { connection ->
-            dslContext.using(connection).preparedQuery(jooqQuery, table)
+            dslContext.using(connection).preparedQuery(jooqQuery).coerce(table).fetch()
         }
     }
 
@@ -57,13 +58,13 @@ class JdbcQueryExecutor(
         return if (returning == null) {
             jooqQuery.setReturning()
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                dslContext.using(connection).preparedQuery(jooqQuery, table)
+                dslContext.using(connection).preparedQuery(jooqQuery).coerce(table).fetch()
             }
         } else {
             require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
             jooqQuery.setReturning(returning)
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                dslContext.using(connection).preparedQuery(jooqQuery, returning).map { it.into(table) }
+                dslContext.using(connection).preparedQuery(jooqQuery).coerce(returning).fetch().map { it.into(table) }
             }
         }
     }
@@ -85,27 +86,15 @@ class JdbcQueryExecutor(
         }
     }
 
-    private fun <R : Record> DSLContext.preparedQuery(
-        jooqQuery: Query,
-        table: Table<R>,
-    ): List<R> = resultQuery(
-        render(jooqQuery),
-        *extractParams(jooqQuery)
-            .values
-            .filterNot(Param<*>::isInline)
-            .toTypedArray(),
-    ).coerce(table).fetch()
-
     private fun DSLContext.preparedQuery(
         jooqQuery: Query,
-        returning: Collection<Field<*>>,
-    ): List<Record> = resultQuery(
+    ): ResultQuery<Record> = resultQuery(
         render(jooqQuery),
         *extractParams(jooqQuery)
             .values
             .filterNot(Param<*>::isInline)
             .toTypedArray(),
-    ).coerce(returning).fetch()
+    )
 
     override fun extractConstraintName(ex: Exception): Constraint? {
         val dataAccessException = ex as? DataAccessException ?: return null

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -10,6 +10,7 @@ import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
@@ -61,10 +62,10 @@ class JdbcQueryExecutor(
                 dslContext.using(connection).preparedQuery(jooqQuery).coerce(table).fetch()
             }
         } else {
-            require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
-            jooqQuery.setReturning(returning)
+            val fields = matchReturning(jooqQuery, returning)
+            jooqQuery.setReturning(fields)
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                dslContext.using(connection).preparedQuery(jooqQuery).coerce(returning).fetch().map { it.into(table) }
+                dslContext.using(connection).preparedQuery(jooqQuery).coerce(fields).fetch().map { it.into(table) }
             }
         }
     }

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -18,6 +18,7 @@ import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.OpenTelemetry.noop
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.Param
 import org.jooq.Query
 import org.jooq.Record
@@ -58,6 +59,19 @@ class JdbcQueryExecutor(
         }
     }
 
+    override suspend fun <RIN : Record, ROUT : Record> executeStore(
+        dslContext: DSLContext,
+        jooqQuery: StoreQuery<RIN>,
+        table: Table<ROUT>,
+        returning: Collection<Field<*>>,
+    ): List<ROUT> {
+        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+        jooqQuery.setReturning(returning)
+        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+            dslContext.using(connection).preparedQuery(jooqQuery, returning).map { it.into(table) }
+        }
+    }
+
     override suspend fun <R : Record> executeQuery(
         dslContext: DSLContext,
         jooqQuery: DMLQuery<R>,
@@ -85,6 +99,17 @@ class JdbcQueryExecutor(
             .filterNot(Param<*>::isInline)
             .toTypedArray(),
     ).coerce(table).fetch()
+
+    private fun DSLContext.preparedQuery(
+        jooqQuery: Query,
+        returning: Collection<Field<*>>,
+    ): List<Record> = resultQuery(
+        render(jooqQuery),
+        *extractParams(jooqQuery)
+            .values
+            .filterNot(Param<*>::isInline)
+            .toTypedArray(),
+    ).coerce(returning).fetch()
 
     override fun extractConstraintName(ex: Exception): Constraint? {
         val dataAccessException = ex as? DataAccessException ?: return null

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
@@ -224,14 +224,40 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
                 }
 
                 Then("Returning clause contains only the requested fields") {
-                    val returning = capturedSql.single().substringAfter("returning")
-                    returning shouldContain "\"id\""
-                    returning shouldNotContain "\"name\""
+                    capturedSql.single() shouldContain "returning \"store_test\".\"id\""
+                    capturedSql.single().substringAfter("returning") shouldNotContain "\"name\""
                 }
                 And("Only the requested fields are populated") {
                     val record = stored.single()
                     record.get(storeTable.ID) shouldBe id
                     record.get(storeTable.NAME) shouldBe null
+                }
+            }
+        }
+
+        And("Mock connection returning requested fields for an aliased update") {
+            val capturedSql = mutableListOf<String>()
+            val connection = MockConnection { ctx ->
+                capturedSql += ctx.sql()
+                val result = DSL.using(POSTGRES).newResult(storeTable.ID)
+                result.add(DSL.using(POSTGRES).newRecord(storeTable.ID).values(id))
+                arrayOf(MockResult(1, result))
+            }
+
+            When("Principal calls execute store with fields of the unaliased table") {
+                val aliased = storeTable.`as`("t")
+                val update = dslContext.updateQuery(aliased).apply {
+                    addValue(DSL.field(DSL.name("t", "name"), String::class.java), "razz")
+                }
+                val stored = withContext(Dispatchers.IO + JdbcConnectionElement(connection)) {
+                    executor.executeStore(dslContext, update, storeTable, listOf(storeTable.ID))
+                }
+
+                Then("Returning clause is requalified with the alias") {
+                    capturedSql.single() shouldContain "returning \"t\".\"id\""
+                }
+                And("Requested fields are populated") {
+                    stored.single().get(storeTable.ID) shouldBe id
                 }
             }
         }
@@ -279,9 +305,7 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
                 }
 
                 Then("Returning clause contains all table columns") {
-                    val returning = capturedSql.single().substringAfter("returning")
-                    returning shouldContain "\"id\""
-                    returning shouldContain "\"name\""
+                    capturedSql.single() shouldContain "returning \"store_test\".\"id\", \"store_test\".\"name\""
                 }
                 And("All fields are populated") {
                     val record = stored.single()

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
@@ -236,6 +236,34 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
             }
         }
 
+        And("Mock connection returning requested fields for two rows") {
+            val secondId = UUID.fromString("06c04353-c8e4-4ea9-a973-c688a6779b04")
+            val connection = MockConnection {
+                val result = DSL.using(POSTGRES).newResult(storeTable.ID)
+                result.add(DSL.using(POSTGRES).newRecord(storeTable.ID).values(id))
+                result.add(DSL.using(POSTGRES).newRecord(storeTable.ID).values(secondId))
+                arrayOf(MockResult(2, result))
+            }
+
+            When("Principal calls execute store for two rows with explicit returning fields") {
+                val insert = dslContext.insertQuery(storeTable).apply {
+                    addValue(storeTable.ID, id)
+                    addValue(storeTable.NAME, "razz")
+                    newRecord()
+                    addValue(storeTable.ID, secondId)
+                    addValue(storeTable.NAME, "team")
+                }
+                val stored = withContext(Dispatchers.IO + JdbcConnectionElement(connection)) {
+                    executor.executeStore(dslContext, insert, storeTable, listOf(storeTable.ID))
+                }
+
+                Then("Each returned record has only the requested fields populated") {
+                    stored.map { it.get(storeTable.ID) } shouldBe listOf(id, secondId)
+                    stored.map { it.get(storeTable.NAME) } shouldBe listOf(null, null)
+                }
+            }
+        }
+
         And("Mock connection returning full rows") {
             val capturedSql = mutableListOf<String>()
             val connection = MockConnection { ctx ->

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorSpec.kt
@@ -7,6 +7,8 @@ import com.razz.eva.persistence.jdbc.JdbcTransactionManager
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.mockk.clearMocks
 import io.mockk.coEvery
@@ -16,11 +18,22 @@ import io.mockk.spyk
 import io.opentelemetry.api.OpenTelemetry.noop
 import java.sql.Connection
 import java.sql.SQLException
+import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.jooq.Record
 import org.jooq.SQLDialect.POSTGRES
 import org.jooq.exception.DataAccessException
 import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockResult
+
+private val storeTable = object : TableImpl<Record>(DSL.name("store_test")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)
+    val NAME = createField(DSL.name("name"), SQLDataType.VARCHAR)
+}
 
 class JdbcQueryExecutorSpec : BehaviorSpec({
 
@@ -182,6 +195,80 @@ class JdbcQueryExecutorSpec : BehaviorSpec({
                         connectionProvider.release(connection)
                     }
                 }
+            }
+        }
+    }
+
+    Given("Jdbc query executor over a jooq mock connection") {
+        val connectionProvider = mockk<JdbcConnectionProvider>(relaxed = true)
+        val executor = JdbcQueryExecutor(JdbcTransactionManager(connectionProvider, connectionProvider), noop())
+        val id = UUID.fromString("b1e9a6a4-3c56-4864-9d9a-4ba33b0480e5")
+
+        fun insertQuery() = dslContext.insertQuery(storeTable).apply {
+            addValue(storeTable.ID, id)
+            addValue(storeTable.NAME, "razz")
+        }
+
+        And("Mock connection returning requested fields") {
+            val capturedSql = mutableListOf<String>()
+            val connection = MockConnection { ctx ->
+                capturedSql += ctx.sql()
+                val result = DSL.using(POSTGRES).newResult(storeTable.ID)
+                result.add(DSL.using(POSTGRES).newRecord(storeTable.ID).values(id))
+                arrayOf(MockResult(1, result))
+            }
+
+            When("Principal calls execute store with explicit returning fields") {
+                val stored = withContext(Dispatchers.IO + JdbcConnectionElement(connection)) {
+                    executor.executeStore(dslContext, insertQuery(), storeTable, listOf(storeTable.ID))
+                }
+
+                Then("Returning clause contains only the requested fields") {
+                    val returning = capturedSql.single().substringAfter("returning")
+                    returning shouldContain "\"id\""
+                    returning shouldNotContain "\"name\""
+                }
+                And("Only the requested fields are populated") {
+                    val record = stored.single()
+                    record.get(storeTable.ID) shouldBe id
+                    record.get(storeTable.NAME) shouldBe null
+                }
+            }
+        }
+
+        And("Mock connection returning full rows") {
+            val capturedSql = mutableListOf<String>()
+            val connection = MockConnection { ctx ->
+                capturedSql += ctx.sql()
+                val result = DSL.using(POSTGRES).newResult(storeTable.ID, storeTable.NAME)
+                result.add(DSL.using(POSTGRES).newRecord(storeTable.ID, storeTable.NAME).values(id, "razz"))
+                arrayOf(MockResult(1, result))
+            }
+
+            When("Principal calls execute store without explicit returning fields") {
+                val stored = withContext(Dispatchers.IO + JdbcConnectionElement(connection)) {
+                    executor.executeStore(dslContext, insertQuery(), storeTable)
+                }
+
+                Then("Returning clause contains all table columns") {
+                    val returning = capturedSql.single().substringAfter("returning")
+                    returning shouldContain "\"id\""
+                    returning shouldContain "\"name\""
+                }
+                And("All fields are populated") {
+                    val record = stored.single()
+                    record.get(storeTable.ID) shouldBe id
+                    record.get(storeTable.NAME) shouldBe "razz"
+                }
+            }
+        }
+
+        When("Principal calls execute store with empty returning fields") {
+            Then("Exception thrown saying returning fields must not be empty") {
+                val ex = shouldThrow<IllegalArgumentException> {
+                    executor.executeStore(dslContext, insertQuery(), storeTable, listOf())
+                }
+                ex.message shouldBe "Returning fields must not be empty, use executeQuery for a row count"
             }
         }
     }

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -10,6 +10,7 @@ import com.razz.eva.persistence.PersistenceException.StaleRecordException
 import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationException
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
+import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
@@ -67,16 +68,14 @@ class VertxQueryExecutor(
         table: Table<ROUT>,
         returning: Collection<Field<*>>?,
     ): List<ROUT> {
-        require(returning == null || returning.isNotEmpty()) {
-            "Returning fields must not be empty, use executeQuery for a row count"
-        }
+        val matched = returning?.let { matchReturning(jooqQuery, it) }
         return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            val fields = if (returning == null) {
+            val fields = if (matched == null) {
                 jooqQuery.setReturning()
                 table.fields()
             } else {
-                jooqQuery.setReturning(returning)
-                returning.toTypedArray()
+                jooqQuery.setReturning(matched)
+                matched.toTypedArray()
             }
             val rows = executeQuery(connection, dslContext, jooqQuery, fields, table)
             rows.toList()

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -26,6 +26,7 @@ import io.vertx.sqlclient.impl.ListTuple
 import org.jooq.Converter
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.JSON
 import org.jooq.JSONB
 import org.jooq.Query
@@ -55,7 +56,7 @@ class VertxQueryExecutor(
         table: Table<R>,
     ): List<R> {
         return transactionManager.withConnection { connection ->
-            val rows = executeQuery(connection, dslContext, jooqQuery, table)
+            val rows = executeQuery(connection, dslContext, jooqQuery, table.fields(), table)
             rows.toList()
         }
     }
@@ -67,7 +68,21 @@ class VertxQueryExecutor(
     ): List<ROUT> {
         return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
             jooqQuery.setReturning()
-            val rows = executeQuery(connection, dslContext, jooqQuery, table)
+            val rows = executeQuery(connection, dslContext, jooqQuery, table.fields(), table)
+            rows.toList()
+        }
+    }
+
+    override suspend fun <RIN : Record, ROUT : Record> executeStore(
+        dslContext: DSLContext,
+        jooqQuery: StoreQuery<RIN>,
+        table: Table<ROUT>,
+        returning: Collection<Field<*>>,
+    ): List<ROUT> {
+        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+            jooqQuery.setReturning(returning)
+            val rows = executeQuery(connection, dslContext, jooqQuery, returning.toTypedArray(), table)
             rows.toList()
         }
     }
@@ -86,9 +101,10 @@ class VertxQueryExecutor(
         connection: PgConnection,
         dslContext: DSLContext,
         jooqQuery: Query,
+        fields: Array<out Field<*>>,
         table: Table<R>,
     ): RowSet<R> = connection.preparedQuery(dslContext.renderNamedParams(jooqQuery)).mapping { row ->
-        convertRowToRecord(dslContext, row, table)
+        convertRowToRecord(dslContext, row, fields, table)
     }.execute(bindParams(dslContext, jooqQuery)).coAwait()
 
     private fun bindParams(
@@ -114,9 +130,9 @@ class VertxQueryExecutor(
     private fun <R : Record> convertRowToRecord(
         dslContext: DSLContext,
         row: Row,
+        fields: Array<out Field<*>>,
         table: Table<R>,
     ): R {
-        val fields = table.fields()
         val values = arrayOfNulls<Any>(fields.size)
         for (i in fields.indices) {
             val field = fields[i]
@@ -141,7 +157,7 @@ class VertxQueryExecutor(
             }
         }
 
-        val record = dslContext.newRecord(table)
+        val record = dslContext.newRecord(*fields)
         record.fromArray(*values)
         record.touched(false)
         return record.into(table)

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -65,24 +65,20 @@ class VertxQueryExecutor(
         dslContext: DSLContext,
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
+        returning: Collection<Field<*>>?,
     ): List<ROUT> {
-        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            jooqQuery.setReturning()
-            val rows = executeQuery(connection, dslContext, jooqQuery, table.fields(), table)
-            rows.toList()
+        require(returning == null || returning.isNotEmpty()) {
+            "Returning fields must not be empty, use executeQuery for a row count"
         }
-    }
-
-    override suspend fun <RIN : Record, ROUT : Record> executeStore(
-        dslContext: DSLContext,
-        jooqQuery: StoreQuery<RIN>,
-        table: Table<ROUT>,
-        returning: Collection<Field<*>>,
-    ): List<ROUT> {
-        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
         return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            jooqQuery.setReturning(returning)
-            val rows = executeQuery(connection, dslContext, jooqQuery, returning.toTypedArray(), table)
+            val fields = if (returning == null) {
+                jooqQuery.setReturning()
+                table.fields()
+            } else {
+                jooqQuery.setReturning(returning)
+                returning.toTypedArray()
+            }
+            val rows = executeQuery(connection, dslContext, jooqQuery, fields, table)
             rows.toList()
         }
     }

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorReturningSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorReturningSpec.kt
@@ -43,12 +43,11 @@ class VertxQueryExecutorReturningSpec : ShouldSpec({
 
     val sqlSlot = slot<String>()
     val mappingSlot = slot<Function<Row, Record>>()
-    val paramsSlot = slot<ListTuple>()
 
     val preparedQueryMock = mockk<PreparedQuery<RowSet<Row>>> {
         every { mapping(capture(mappingSlot)) } answers {
             mockk {
-                every { execute(capture(paramsSlot)) } returns succeededFuture(
+                every { execute(any<ListTuple>()) } returns succeededFuture(
                     mockk {
                         every { iterator() } answers {
                             mockk { every { hasNext() } returns false }
@@ -80,9 +79,8 @@ class VertxQueryExecutorReturningSpec : ShouldSpec({
             executor.executeStore(dslContext, insertQuery(), storeTable, listOf(storeTable.ID))
         }
 
-        val returning = sqlSlot.captured.substringAfter("returning")
-        returning shouldContain "\"id\""
-        returning shouldNotContain "\"name\""
+        sqlSlot.captured shouldContain "returning \"store_test\".\"id\""
+        sqlSlot.captured.substringAfter("returning") shouldNotContain "\"name\""
     }
 
     should("populate only caller-provided returning fields") {
@@ -104,9 +102,7 @@ class VertxQueryExecutorReturningSpec : ShouldSpec({
             executor.executeStore(dslContext, insertQuery(), storeTable)
         }
 
-        val returning = sqlSlot.captured.substringAfter("returning")
-        returning shouldContain "\"id\""
-        returning shouldContain "\"name\""
+        sqlSlot.captured shouldContain "returning \"store_test\".\"id\", \"store_test\".\"name\""
     }
 
     should("reject empty returning fields") {

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorReturningSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorReturningSpec.kt
@@ -1,0 +1,118 @@
+package com.razz.eva.persistence.vertx.executor
+
+import com.razz.eva.persistence.vertx.PgPoolConnectionProvider
+import com.razz.eva.persistence.vertx.VertxConnectionElement
+import com.razz.eva.persistence.vertx.VertxTransactionManager
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.vertx.core.Future.succeededFuture
+import io.vertx.pgclient.PgConnection
+import io.vertx.sqlclient.PreparedQuery
+import io.vertx.sqlclient.Row
+import io.vertx.sqlclient.RowSet
+import io.vertx.sqlclient.impl.ListTuple
+import java.util.UUID
+import java.util.function.Function
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jooq.Record
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+
+private val storeTable = object : TableImpl<Record>(DSL.name("store_test")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)
+    val NAME = createField(DSL.name("name"), SQLDataType.VARCHAR)
+}
+
+class VertxQueryExecutorReturningSpec : ShouldSpec({
+
+    val dslContext = DSL.using(POSTGRES)
+    val connectionProvider = mockk<PgPoolConnectionProvider>(relaxed = true)
+    val transactionManager = spyk(VertxTransactionManager(connectionProvider, connectionProvider))
+    val executor = VertxQueryExecutor(transactionManager)
+
+    val sqlSlot = slot<String>()
+    val mappingSlot = slot<Function<Row, Record>>()
+    val paramsSlot = slot<ListTuple>()
+
+    val preparedQueryMock = mockk<PreparedQuery<RowSet<Row>>> {
+        every { mapping(capture(mappingSlot)) } answers {
+            mockk {
+                every { execute(capture(paramsSlot)) } returns succeededFuture(
+                    mockk {
+                        every { iterator() } answers {
+                            mockk { every { hasNext() } returns false }
+                        }
+                        every { size() } returns 0
+                    },
+                )
+            }
+        }
+    }
+
+    val connection = mockk<PgConnection>(relaxed = true) {
+        every { preparedQuery(capture(sqlSlot)) } answers { preparedQueryMock }
+    }
+
+    fun resetMocks() {
+        clearMocks(connection, answers = false)
+        every { connection.preparedQuery(capture(sqlSlot)) } answers { preparedQueryMock }
+    }
+
+    fun insertQuery() = dslContext.insertQuery(storeTable).apply {
+        addValue(storeTable.ID, UUID.randomUUID())
+        addValue(storeTable.NAME, "razz")
+    }
+
+    should("render only caller-provided returning fields") {
+        resetMocks()
+        withContext(Dispatchers.IO + VertxConnectionElement(connection)) {
+            executor.executeStore(dslContext, insertQuery(), storeTable, listOf(storeTable.ID))
+        }
+
+        val returning = sqlSlot.captured.substringAfter("returning")
+        returning shouldContain "\"id\""
+        returning shouldNotContain "\"name\""
+    }
+
+    should("populate only caller-provided returning fields") {
+        resetMocks()
+        withContext(Dispatchers.IO + VertxConnectionElement(connection)) {
+            executor.executeStore(dslContext, insertQuery(), storeTable, listOf(storeTable.ID))
+        }
+
+        val id = UUID.randomUUID()
+        val row = mockk<Row> { every { get(UUID::class.java, 0) } returns id }
+        val record = mappingSlot.captured.apply(row)
+        record.get(storeTable.ID) shouldBe id
+        record.get(storeTable.NAME) shouldBe null
+    }
+
+    should("render all table columns when no returning fields provided") {
+        resetMocks()
+        withContext(Dispatchers.IO + VertxConnectionElement(connection)) {
+            executor.executeStore(dslContext, insertQuery(), storeTable)
+        }
+
+        val returning = sqlSlot.captured.substringAfter("returning")
+        returning shouldContain "\"id\""
+        returning shouldContain "\"name\""
+    }
+
+    should("reject empty returning fields") {
+        val ex = shouldThrow<IllegalArgumentException> {
+            executor.executeStore(dslContext, insertQuery(), storeTable, listOf())
+        }
+        ex.message shouldBe "Returning fields must not be empty, use executeQuery for a row count"
+    }
+})

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -25,9 +25,14 @@ interface QueryExecutor {
      * With [returning] omitted or null, the clause expands to all columns of the query's own table
      * and the returned [ROUT] records are fully populated.
      * With explicit [returning] fields, the clause contains exactly those fields and only the ones
-     * belonging to [table] are populated on the returned records.
+     * belonging to [table] are populated on the returned records; fields of expressions or other
+     * tables are returned by the database but dropped from the records. Such partial records carry
+     * no values for the remaining columns and are not suitable for model hydration.
      *
      * Explicit [returning] must not be empty; use [executeQuery] for DML without `RETURNING`.
+     * Explicit [returning] fields render with their own qualification: for a query built on an
+     * aliased table pass fields of the aliased table, otherwise the rendered `RETURNING` references
+     * the table name that the alias hides and the statement fails.
      */
     suspend fun <RIN : Record, ROUT : Record> executeStore(
         dslContext: DSLContext,

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -9,6 +9,8 @@ import org.jooq.Record
 import org.jooq.Select
 import org.jooq.StoreQuery
 import org.jooq.Table
+import org.jooq.TableField
+import org.jooq.impl.QOM
 
 interface QueryExecutor {
 
@@ -24,15 +26,16 @@ interface QueryExecutor {
      *
      * With [returning] omitted or null, the clause expands to all columns of the query's own table
      * and the returned [ROUT] records are fully populated.
-     * With explicit [returning] fields, the clause contains exactly those fields and only the ones
-     * belonging to [table] are populated on the returned records; fields of expressions or other
-     * tables are returned by the database but dropped from the records. Such partial records carry
-     * no values for the remaining columns and are not suitable for model hydration.
+     * With explicit [returning] fields, the clause contains exactly those fields. Returned values
+     * map onto the [table] record by field name: a returned field whose name matches a [table]
+     * column populates that column whatever its origin, and returned names without a match are
+     * dropped. Columns outside [returning] stay null, so such partial records are not suitable
+     * for model hydration.
      *
      * Explicit [returning] must not be empty; use [executeQuery] for DML without `RETURNING`.
-     * Explicit [returning] fields render with their own qualification: for a query built on an
-     * aliased table pass fields of the aliased table, otherwise the rendered `RETURNING` references
-     * the table name that the alias hides and the statement fails.
+     * Explicit [returning] columns are requalified against the query's target table, so for a query
+     * built on an aliased table the `RETURNING` clause renders alias-qualified columns.
+     * Non-column expressions render as passed.
      */
     suspend fun <RIN : Record, ROUT : Record> executeStore(
         dslContext: DSLContext,
@@ -56,4 +59,29 @@ interface QueryExecutor {
 
     @JvmInline
     value class Constraint(val name: String?)
+
+    companion object {
+
+        /**
+         * Requalifies [returning] columns against the target table of [jooqQuery]: a [TableField]
+         * whose name the target table knows resolves to the target's own field, so fields of an
+         * aliased table render with the alias. Non-column expressions and unknown fields are kept
+         * as passed.
+         */
+        fun matchReturning(jooqQuery: StoreQuery<*>, returning: Collection<Field<*>>): List<Field<*>> {
+            require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+            val target = when (jooqQuery) {
+                is QOM.Insert<*> -> jooqQuery.`$into`()
+                is QOM.Update<*> -> jooqQuery.`$table`()
+                else -> null
+            }
+            return if (target == null) {
+                returning.toList()
+            } else {
+                returning.map { field ->
+                    if (field is TableField<*, *>) target.field(field) ?: field else field
+                }
+            }
+        }
+    }
 }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -19,31 +19,21 @@ interface QueryExecutor {
     ): List<R>
 
     /**
-     * Executes [jooqQuery] with a `RETURNING` clause of all [table] columns,
-     * replacing any `RETURNING` clause already set on the query.
-     * Returns fully populated [ROUT] records.
+     * Executes [jooqQuery] with a `RETURNING` clause, replacing any `RETURNING` clause
+     * already set on the query.
      *
-     * Use the overload with explicit [Field]s to control which columns come back,
-     * or [executeQuery] to skip `RETURNING` and get an affected row count.
+     * With [returning] omitted or null, the clause expands to all columns of the query's own table
+     * and the returned [ROUT] records are fully populated.
+     * With explicit [returning] fields, the clause contains exactly those fields and only the ones
+     * belonging to [table] are populated on the returned records.
+     *
+     * Explicit [returning] must not be empty; use [executeQuery] for DML without `RETURNING`.
      */
     suspend fun <RIN : Record, ROUT : Record> executeStore(
         dslContext: DSLContext,
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
-    ): List<ROUT>
-
-    /**
-     * Executes [jooqQuery] with a `RETURNING` clause of exactly [returning] fields,
-     * replacing any `RETURNING` clause already set on the query.
-     * Returns [ROUT] records where only the [returning] fields belonging to [table] are populated.
-     *
-     * [returning] must not be empty; use [executeQuery] for DML without `RETURNING`.
-     */
-    suspend fun <RIN : Record, ROUT : Record> executeStore(
-        dslContext: DSLContext,
-        jooqQuery: StoreQuery<RIN>,
-        table: Table<ROUT>,
-        returning: Collection<Field<*>>,
+        returning: Collection<Field<*>>? = null,
     ): List<ROUT>
 
     suspend fun <R : Record> executeQuery(

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/executor/QueryExecutor.kt
@@ -4,6 +4,7 @@ import com.razz.eva.domain.ModelId
 import com.razz.eva.persistence.PersistenceException
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.Record
 import org.jooq.Select
 import org.jooq.StoreQuery
@@ -17,10 +18,32 @@ interface QueryExecutor {
         table: Table<R>,
     ): List<R>
 
+    /**
+     * Executes [jooqQuery] with a `RETURNING` clause of all [table] columns,
+     * replacing any `RETURNING` clause already set on the query.
+     * Returns fully populated [ROUT] records.
+     *
+     * Use the overload with explicit [Field]s to control which columns come back,
+     * or [executeQuery] to skip `RETURNING` and get an affected row count.
+     */
     suspend fun <RIN : Record, ROUT : Record> executeStore(
         dslContext: DSLContext,
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
+    ): List<ROUT>
+
+    /**
+     * Executes [jooqQuery] with a `RETURNING` clause of exactly [returning] fields,
+     * replacing any `RETURNING` clause already set on the query.
+     * Returns [ROUT] records where only the [returning] fields belonging to [table] are populated.
+     *
+     * [returning] must not be empty; use [executeQuery] for DML without `RETURNING`.
+     */
+    suspend fun <RIN : Record, ROUT : Record> executeStore(
+        dslContext: DSLContext,
+        jooqQuery: StoreQuery<RIN>,
+        table: Table<ROUT>,
+        returning: Collection<Field<*>>,
     ): List<ROUT>
 
     suspend fun <R : Record> executeQuery(

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
@@ -178,13 +178,7 @@ class JooqBaseRepositoryNegativeSpec : BehaviorSpec({
                 dslContext: DSLContext,
                 jooqQuery: StoreQuery<RIN>,
                 table: Table<ROUT>,
-            ): List<ROUT> = TODO("NEVER HAPPENS")
-
-            override suspend fun <RIN : Record, ROUT : Record> executeStore(
-                dslContext: DSLContext,
-                jooqQuery: StoreQuery<RIN>,
-                table: Table<ROUT>,
-                returning: Collection<Field<*>>,
+                returning: Collection<Field<*>>?,
             ): List<ROUT> = TODO("NEVER HAPPENS")
 
             override suspend fun <R : Record> executeQuery(

--- a/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
+++ b/eva-repository/src/test/kotlin/com/razz/eva/repository/JooqBaseRepositoryNegativeSpec.kt
@@ -29,6 +29,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeTypeOf
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.Record
 import org.jooq.SQLDialect.POSTGRES
 import org.jooq.Select
@@ -177,6 +178,13 @@ class JooqBaseRepositoryNegativeSpec : BehaviorSpec({
                 dslContext: DSLContext,
                 jooqQuery: StoreQuery<RIN>,
                 table: Table<ROUT>,
+            ): List<ROUT> = TODO("NEVER HAPPENS")
+
+            override suspend fun <RIN : Record, ROUT : Record> executeStore(
+                dslContext: DSLContext,
+                jooqQuery: StoreQuery<RIN>,
+                table: Table<ROUT>,
+                returning: Collection<Field<*>>,
             ): List<ROUT> = TODO("NEVER HAPPENS")
 
             override suspend fun <R : Record> executeQuery(

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
@@ -8,6 +8,7 @@ import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionSt
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
+import org.jooq.Field
 import org.jooq.Record
 import org.jooq.SQLDialect.POSTGRES
 import org.jooq.Select
@@ -54,6 +55,20 @@ class FakeMemorizingQueryExecutor(
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
     ): List<ROUT> {
+        executions += StoreExecuted(dslContext, jooqQuery, table)
+        return DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
+            .fetch(jooqQuery.getSQL(INLINED))
+            .into(table)
+    }
+
+    override suspend fun <RIN : Record, ROUT : Record> executeStore(
+        dslContext: DSLContext,
+        jooqQuery: StoreQuery<RIN>,
+        table: Table<ROUT>,
+        returning: Collection<Field<*>>,
+    ): List<ROUT> {
+        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+        jooqQuery.setReturning(returning)
         executions += StoreExecuted(dslContext, jooqQuery, table)
         return DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
             .fetch(jooqQuery.getSQL(INLINED))

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
@@ -54,21 +54,12 @@ class FakeMemorizingQueryExecutor(
         dslContext: DSLContext,
         jooqQuery: StoreQuery<RIN>,
         table: Table<ROUT>,
+        returning: Collection<Field<*>>?,
     ): List<ROUT> {
-        executions += StoreExecuted(dslContext, jooqQuery, table)
-        return DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
-            .fetch(jooqQuery.getSQL(INLINED))
-            .into(table)
-    }
-
-    override suspend fun <RIN : Record, ROUT : Record> executeStore(
-        dslContext: DSLContext,
-        jooqQuery: StoreQuery<RIN>,
-        table: Table<ROUT>,
-        returning: Collection<Field<*>>,
-    ): List<ROUT> {
-        require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
-        jooqQuery.setReturning(returning)
+        if (returning != null) {
+            require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
+            jooqQuery.setReturning(returning)
+        }
         executions += StoreExecuted(dslContext, jooqQuery, table)
         return DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
             .fetch(jooqQuery.getSQL(INLINED))

--- a/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
+++ b/eva-repository/src/testFixtures/kotlin/com/razz/eva/persistence/executor/FakeMemorizingQueryExecutor.kt
@@ -5,6 +5,7 @@ import com.razz.eva.persistence.PersistenceException
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.QueryExecuted
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.SelectExecuted
 import com.razz.eva.persistence.executor.FakeMemorizingQueryExecutor.ExecutionStep.StoreExecuted
+import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import org.jooq.DMLQuery
 import org.jooq.DSLContext
@@ -56,14 +57,18 @@ class FakeMemorizingQueryExecutor(
         table: Table<ROUT>,
         returning: Collection<Field<*>>?,
     ): List<ROUT> {
-        if (returning != null) {
-            require(returning.isNotEmpty()) { "Returning fields must not be empty, use executeQuery for a row count" }
-            jooqQuery.setReturning(returning)
+        val fields = returning?.let { matchReturning(jooqQuery, it).toTypedArray() }
+        if (fields != null) {
+            jooqQuery.setReturning(*fields)
         }
         executions += StoreExecuted(dslContext, jooqQuery, table)
-        return DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
+        val fetched = DSL.using(MockConnection(MockProvider(queries)), POSTGRES, dslContext.settings())
             .fetch(jooqQuery.getSQL(INLINED))
-            .into(table)
+        return if (fields == null) {
+            fetched.into(table)
+        } else {
+            fetched.map { it.into(*fields).into(table) }
+        }
     }
 
     override suspend fun <R : Record> executeQuery(

--- a/eva-repository/src/testFixtures/resources/com/razz/eva/test/db/V006__create_raise_serialization_failure.sql
+++ b/eva-repository/src/testFixtures/resources/com/razz/eva/test/db/V006__create_raise_serialization_failure.sql
@@ -1,0 +1,4 @@
+CREATE FUNCTION raise_serialization_failure() RETURNS boolean AS $$
+BEGIN
+    RAISE SQLSTATE '40001' USING MESSAGE = 'Simulated serialization failure';
+END $$ LANGUAGE plpgsql;

--- a/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
+++ b/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
@@ -114,6 +114,55 @@ class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
             }
         }
 
+        When("Principal updates an aliased table without explicit returning fields") {
+            val id = UUID.randomUUID()
+            inTransaction {
+                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
+            }
+            val aliased = DEPARTMENTS.`as`("t")
+            val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
+            val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
+            val update = dslContext.updateQuery(aliased).apply {
+                addValue(aliasedHeadcount, 7)
+                addConditions(aliasedId.eq(id))
+            }
+            val stored = inTransaction {
+                executor.executeStore(dslContext, update, DEPARTMENTS)
+            }
+
+            Then("Full row comes back through the alias-qualified returning") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.HEADCOUNT) shouldBe 7
+                record.get(DEPARTMENTS.NAME) shouldBe "dep-$id"
+                record.get(DEPARTMENTS.VERSION) shouldBe 1L
+            }
+        }
+
+        When("Principal updates an aliased table passing fields of the aliased table") {
+            val id = UUID.randomUUID()
+            inTransaction {
+                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
+            }
+            val aliased = DEPARTMENTS.`as`("t")
+            val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
+            val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
+            val update = dslContext.updateQuery(aliased).apply {
+                addValue(aliasedHeadcount, 13)
+                addConditions(aliasedId.eq(id))
+            }
+            val stored = inTransaction {
+                executor.executeStore(dslContext, update, DEPARTMENTS, listOf(aliasedId, aliasedHeadcount))
+            }
+
+            Then("Requested fields are populated on the unaliased table record") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.HEADCOUNT) shouldBe 13
+                record.get(DEPARTMENTS.NAME) shouldBe null
+            }
+        }
+
         When("Principal inserts with an expression aliased to a column name") {
             val id = UUID.randomUUID()
             val stored = inTransaction {

--- a/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
+++ b/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
@@ -178,5 +178,23 @@ class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
                 stored.single().get(DEPARTMENTS.NAME) shouldBe "dep-$id".uppercase()
             }
         }
+
+        When("Principal inserts with a column aliased to a name outside the table") {
+            val id = UUID.randomUUID()
+            val stored = inTransaction {
+                executor.executeStore(
+                    dslContext,
+                    insertQuery(id),
+                    DEPARTMENTS,
+                    listOf(DEPARTMENTS.ID, DEPARTMENTS.NAME.`as`("title")),
+                )
+            }
+
+            Then("The database returns the aliased column but no record column matches it") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.NAME) shouldBe null
+            }
+        }
     }
 })

--- a/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
+++ b/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
@@ -1,0 +1,133 @@
+package com.razz.eva.repository
+
+import com.razz.eva.test.repository.RepositorySpec
+import com.razz.eva.test.schema.Tables.DEPARTMENTS
+import com.razz.eva.test.schema.enums.DepartmentsState.OWNED
+import io.kotest.matchers.shouldBe
+import java.util.UUID
+import org.jooq.impl.DSL
+
+class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
+
+    fun insertQuery(id: UUID) = dslContext.insertQuery(DEPARTMENTS).apply {
+        addValue(DEPARTMENTS.ID, id)
+        addValue(DEPARTMENTS.NAME, "dep-$id")
+        addValue(DEPARTMENTS.BOSS, UUID.randomUUID())
+        addValue(DEPARTMENTS.HEADCOUNT, 1)
+        addValue(DEPARTMENTS.RATION, "BUBALEH")
+        addValue(DEPARTMENTS.STATE, OWNED)
+        addValue(DEPARTMENTS.RECORD_UPDATED_AT, now)
+        addValue(DEPARTMENTS.RECORD_CREATED_AT, now)
+        addValue(DEPARTMENTS.VERSION, 1L)
+    }
+
+    Given("Query executor over a real database") {
+
+        When("Principal inserts without explicit returning fields") {
+            val id = UUID.randomUUID()
+            val stored = inTransaction {
+                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
+            }
+
+            Then("All columns are populated") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.NAME) shouldBe "dep-$id"
+                record.get(DEPARTMENTS.STATE) shouldBe OWNED
+                record.get(DEPARTMENTS.RECORD_UPDATED_AT) shouldBe now
+                record.get(DEPARTMENTS.VERSION) shouldBe 1L
+            }
+        }
+
+        When("Principal inserts with explicit returning fields") {
+            val id = UUID.randomUUID()
+            val stored = inTransaction {
+                executor.executeStore(
+                    dslContext,
+                    insertQuery(id),
+                    DEPARTMENTS,
+                    listOf(DEPARTMENTS.ID, DEPARTMENTS.STATE, DEPARTMENTS.RECORD_UPDATED_AT),
+                )
+            }
+
+            Then("Only the requested fields are populated") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.STATE) shouldBe OWNED
+                record.get(DEPARTMENTS.RECORD_UPDATED_AT) shouldBe now
+                record.get(DEPARTMENTS.NAME) shouldBe null
+                record.get(DEPARTMENTS.VERSION) shouldBe null
+            }
+        }
+
+        When("Principal inserts two rows with explicit returning fields") {
+            val firstId = UUID.randomUUID()
+            val secondId = UUID.randomUUID()
+            val insert = insertQuery(firstId).apply {
+                newRecord()
+                addValue(DEPARTMENTS.ID, secondId)
+                addValue(DEPARTMENTS.NAME, "dep-$secondId")
+                addValue(DEPARTMENTS.BOSS, UUID.randomUUID())
+                addValue(DEPARTMENTS.HEADCOUNT, 2)
+                addValue(DEPARTMENTS.RATION, "SHAKSHOUKA")
+                addValue(DEPARTMENTS.STATE, OWNED)
+                addValue(DEPARTMENTS.RECORD_UPDATED_AT, now)
+                addValue(DEPARTMENTS.RECORD_CREATED_AT, now)
+                addValue(DEPARTMENTS.VERSION, 1L)
+            }
+            val stored = inTransaction {
+                executor.executeStore(dslContext, insert, DEPARTMENTS, listOf(DEPARTMENTS.ID))
+            }
+
+            Then("Each returned record carries only its id") {
+                stored.map { it.get(DEPARTMENTS.ID) } shouldBe listOf(firstId, secondId)
+                stored.map { it.get(DEPARTMENTS.NAME) } shouldBe listOf(null, null)
+            }
+        }
+
+        When("Principal updates an aliased table passing fields of the unaliased table") {
+            val id = UUID.randomUUID()
+            inTransaction {
+                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
+            }
+            val aliased = DEPARTMENTS.`as`("t")
+            val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
+            val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
+            val update = dslContext.updateQuery(aliased).apply {
+                addValue(aliasedHeadcount, 42)
+                addConditions(aliasedId.eq(id))
+            }
+            val stored = inTransaction {
+                executor.executeStore(
+                    dslContext,
+                    update,
+                    DEPARTMENTS,
+                    listOf(DEPARTMENTS.ID, DEPARTMENTS.HEADCOUNT),
+                )
+            }
+
+            Then("Returning fields are requalified with the alias and the statement executes") {
+                val record = stored.single()
+                record.get(DEPARTMENTS.ID) shouldBe id
+                record.get(DEPARTMENTS.HEADCOUNT) shouldBe 42
+                record.get(DEPARTMENTS.NAME) shouldBe null
+            }
+        }
+
+        When("Principal inserts with an expression aliased to a column name") {
+            val id = UUID.randomUUID()
+            val stored = inTransaction {
+                executor.executeStore(
+                    dslContext,
+                    insertQuery(id),
+                    DEPARTMENTS,
+                    listOf(DEPARTMENTS.ID, DSL.upper(DEPARTMENTS.NAME).`as`("name")),
+                )
+            }
+
+            Then("Expression value populates the column matched by name") {
+                stored.single().get(DEPARTMENTS.NAME) shouldBe "dep-$id".uppercase()
+            }
+        }
+    }
+})

--- a/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
+++ b/eva-test/src/test/kotlin/com/razz/eva/repository/QueryExecutorReturningSpec.kt
@@ -39,23 +39,30 @@ class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
             }
         }
 
-        When("Principal inserts with explicit returning fields") {
+        When("Principal inserts returning plain columns, an expression and a column aliased outside the table") {
             val id = UUID.randomUUID()
             val stored = inTransaction {
                 executor.executeStore(
                     dslContext,
                     insertQuery(id),
                     DEPARTMENTS,
-                    listOf(DEPARTMENTS.ID, DEPARTMENTS.STATE, DEPARTMENTS.RECORD_UPDATED_AT),
+                    listOf(
+                        DEPARTMENTS.ID,
+                        DEPARTMENTS.STATE,
+                        DEPARTMENTS.RECORD_UPDATED_AT,
+                        DSL.upper(DEPARTMENTS.NAME).`as`("name"),
+                        DEPARTMENTS.RATION.`as`("meal"),
+                    ),
                 )
             }
 
-            Then("Only the requested fields are populated") {
+            Then("Plain columns and the name-matched expression are populated, the rest stays null") {
                 val record = stored.single()
                 record.get(DEPARTMENTS.ID) shouldBe id
                 record.get(DEPARTMENTS.STATE) shouldBe OWNED
                 record.get(DEPARTMENTS.RECORD_UPDATED_AT) shouldBe now
-                record.get(DEPARTMENTS.NAME) shouldBe null
+                record.get(DEPARTMENTS.NAME) shouldBe "dep-$id".uppercase()
+                record.get(DEPARTMENTS.RATION) shouldBe null
                 record.get(DEPARTMENTS.VERSION) shouldBe null
             }
         }
@@ -85,7 +92,7 @@ class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
             }
         }
 
-        When("Principal updates an aliased table passing fields of the unaliased table") {
+        When("Principal updates an aliased table") {
             val id = UUID.randomUUID()
             inTransaction {
                 executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
@@ -93,106 +100,42 @@ class QueryExecutorReturningSpec : RepositorySpec(TestEvaRepositoryHelper, {
             val aliased = DEPARTMENTS.`as`("t")
             val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
             val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
-            val update = dslContext.updateQuery(aliased).apply {
-                addValue(aliasedHeadcount, 42)
+            fun updateQuery(headcount: Int) = dslContext.updateQuery(aliased).apply {
+                addValue(aliasedHeadcount, headcount)
                 addConditions(aliasedId.eq(id))
             }
-            val stored = inTransaction {
+            val unaliasedFields = inTransaction {
                 executor.executeStore(
                     dslContext,
-                    update,
+                    updateQuery(42),
                     DEPARTMENTS,
                     listOf(DEPARTMENTS.ID, DEPARTMENTS.HEADCOUNT),
                 )
             }
+            val fullRow = inTransaction {
+                executor.executeStore(dslContext, updateQuery(7), DEPARTMENTS)
+            }
+            val aliasedFields = inTransaction {
+                executor.executeStore(dslContext, updateQuery(13), DEPARTMENTS, listOf(aliasedId, aliasedHeadcount))
+            }
 
-            Then("Returning fields are requalified with the alias and the statement executes") {
-                val record = stored.single()
+            Then("Fields of the unaliased table are requalified with the alias and the statement executes") {
+                val record = unaliasedFields.single()
                 record.get(DEPARTMENTS.ID) shouldBe id
                 record.get(DEPARTMENTS.HEADCOUNT) shouldBe 42
                 record.get(DEPARTMENTS.NAME) shouldBe null
             }
-        }
-
-        When("Principal updates an aliased table without explicit returning fields") {
-            val id = UUID.randomUUID()
-            inTransaction {
-                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
-            }
-            val aliased = DEPARTMENTS.`as`("t")
-            val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
-            val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
-            val update = dslContext.updateQuery(aliased).apply {
-                addValue(aliasedHeadcount, 7)
-                addConditions(aliasedId.eq(id))
-            }
-            val stored = inTransaction {
-                executor.executeStore(dslContext, update, DEPARTMENTS)
-            }
-
-            Then("Full row comes back through the alias-qualified returning") {
-                val record = stored.single()
+            And("Without explicit fields the full row comes back through the alias-qualified returning") {
+                val record = fullRow.single()
                 record.get(DEPARTMENTS.ID) shouldBe id
                 record.get(DEPARTMENTS.HEADCOUNT) shouldBe 7
                 record.get(DEPARTMENTS.NAME) shouldBe "dep-$id"
                 record.get(DEPARTMENTS.VERSION) shouldBe 1L
             }
-        }
-
-        When("Principal updates an aliased table passing fields of the aliased table") {
-            val id = UUID.randomUUID()
-            inTransaction {
-                executor.executeStore(dslContext, insertQuery(id), DEPARTMENTS)
-            }
-            val aliased = DEPARTMENTS.`as`("t")
-            val aliasedId = requireNotNull(aliased.field(DEPARTMENTS.ID))
-            val aliasedHeadcount = requireNotNull(aliased.field(DEPARTMENTS.HEADCOUNT))
-            val update = dslContext.updateQuery(aliased).apply {
-                addValue(aliasedHeadcount, 13)
-                addConditions(aliasedId.eq(id))
-            }
-            val stored = inTransaction {
-                executor.executeStore(dslContext, update, DEPARTMENTS, listOf(aliasedId, aliasedHeadcount))
-            }
-
-            Then("Requested fields are populated on the unaliased table record") {
-                val record = stored.single()
+            And("Fields of the aliased table are populated on the unaliased table record") {
+                val record = aliasedFields.single()
                 record.get(DEPARTMENTS.ID) shouldBe id
                 record.get(DEPARTMENTS.HEADCOUNT) shouldBe 13
-                record.get(DEPARTMENTS.NAME) shouldBe null
-            }
-        }
-
-        When("Principal inserts with an expression aliased to a column name") {
-            val id = UUID.randomUUID()
-            val stored = inTransaction {
-                executor.executeStore(
-                    dslContext,
-                    insertQuery(id),
-                    DEPARTMENTS,
-                    listOf(DEPARTMENTS.ID, DSL.upper(DEPARTMENTS.NAME).`as`("name")),
-                )
-            }
-
-            Then("Expression value populates the column matched by name") {
-                stored.single().get(DEPARTMENTS.NAME) shouldBe "dep-$id".uppercase()
-            }
-        }
-
-        When("Principal inserts with a column aliased to a name outside the table") {
-            val id = UUID.randomUUID()
-            val stored = inTransaction {
-                executor.executeStore(
-                    dslContext,
-                    insertQuery(id),
-                    DEPARTMENTS,
-                    listOf(DEPARTMENTS.ID, DEPARTMENTS.NAME.`as`("title")),
-                )
-            }
-
-            Then("The database returns the aliased column but no record column matches it") {
-                val record = stored.single()
-                record.get(DEPARTMENTS.ID) shouldBe id
                 record.get(DEPARTMENTS.NAME) shouldBe null
             }
         }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
@@ -6,7 +6,6 @@ import com.razz.eva.domain.DepartmentId
 import com.razz.eva.domain.Employee
 import com.razz.eva.events.EventPublisher
 import com.razz.eva.events.UowEvent
-import com.razz.eva.persistence.ConnectionMode.REQUIRE_EXISTING
 import com.razz.eva.persistence.config.DatabaseConfig
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.eva.repository.BubalehRepository
@@ -138,22 +137,10 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
             table: Table<ROUT>,
             returning: Collection<Field<*>>?,
         ): List<ROUT> {
-            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                DSL.using(
-                    dslContext.configuration()
-                        .derive(connection as java.sql.Connection)
-                        .derive(dslContext.settings()),
-                ).run {
-                    execute(
-                        """
-                        DO $$ 
-                        BEGIN 
-                          RAISE SQLSTATE '40001' USING MESSAGE = 'Simulated serialization failure'; 
-                        END $$;
-                        """.trimIndent(),
-                    )
-                }
+            val rollingBack = dslContext.deleteQuery(DSL.table("departments")).apply {
+                addConditions(DSL.condition("raise_serialization_failure()"))
             }
+            queryExecutor.executeQuery(dslContext, rollingBack)
             return queryExecutor.executeStore(dslContext, jooqQuery, table, returning)
         }
     }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/func/TestModule.kt
@@ -136,6 +136,7 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
             dslContext: DSLContext,
             jooqQuery: StoreQuery<RIN>,
             table: Table<ROUT>,
+            returning: Collection<Field<*>>?,
         ): List<ROUT> {
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
                 DSL.using(
@@ -153,7 +154,7 @@ class TestModule(config: DatabaseConfig) : TransactionalModule(config) {
                     )
                 }
             }
-            return queryExecutor.executeStore(dslContext, jooqQuery, table)
+            return queryExecutor.executeStore(dslContext, jooqQuery, table, returning)
         }
     }
 


### PR DESCRIPTION
Closes #299.

Both query executors call the no-arg `setReturning()` on every `StoreQuery`, so a caller-set RETURNING clause is discarded and every insert or update returns full rows.

This changes `executeStore` to take an optional returning field list:

```kotlin
queryExecutor.executeStore(dslContext, updateQuery, TABLE, listOf(TABLE.ID))
```

With `returning` omitted or null the behavior is unchanged: the clause expands to all columns of the query's own table (model repositories rely on full-row rehydration) and records come back fully populated. With explicit fields, the clause contains exactly those fields; returned values map onto the `table` record by field name and columns outside the list stay null. An explicit empty collection is rejected; `executeQuery` is the row-count variant.

The null default deliberately maps to jOOQ's no-arg `setReturning()` instead of `table.fields()`: the no-arg call expands against the query's own table, which matters for updates built on aliased tables (`AbstractJooqRepository.updateRecords` renders `update "x" as "T"`, where `RETURNING` must reference the alias and unaliased fields are invalid in Postgres).

Explicit fields get the same aliasing treatment via `QueryExecutor.matchReturning`: table columns are requalified against the query's target table (read through jOOQ's QOM interfaces, `QOM.Insert.$into()` / `QOM.Update.$table()`), so `executeStore(dsl, updateQueryOnAliasedTable, TABLE, listOf(TABLE.ID))` renders `returning "t"."id"` instead of invalid unaliased SQL. Non-column expressions and unknown fields pass through untouched. QOM is marked experimental in jOOQ, but usage is compile-checked and pinned by the BOM, and the fallback for non-QOM queries is pass-through.

The issue's other option, applying `setReturning()` only when the caller did not set one, is not implementable through the public jOOQ API: `StoreQuery` has no getter for the requested returning fields (the QOM returning accessors exist only on the DSL `ResultQuery` wrapper types), and `AbstractDMLQuery.returning` is package-private.

`VertxQueryExecutor.convertRowToRecord` is generalized to convert rows by an explicit field list; the full-table path passes `table.fields()` as before. `FakeMemorizingQueryExecutor` narrows its mock results to the requested fields so tests see the same partial records as the real executors.

Compatibility: source-compatible for callers (existing three-arg calls pick up the default) but binary-incompatible with jars compiled against earlier versions, and `QueryExecutor` implementors must adjust the override signature. Consumers need a recompile against this version.