### PR TITLE
Inline the JSONB key in JsonDSL and rework the jOOQ DSL helpers

### DIFF
--- a/eva-jooq/src/main/kotlin/com/razz/jooq/dsl/DSLs.kt
+++ b/eva-jooq/src/main/kotlin/com/razz/jooq/dsl/DSLs.kt
@@ -58,6 +58,21 @@ object JsonDSL {
     fun jsonbStringIn(field: Field<JSONB>, name: String, values: Collection<String>): Condition =
         jsonbField(field, name).eqAny(values)
 
+    /**
+     * The jsonb array at `field->'name'` as a text list, empty when the key is absent or the array is
+     * empty. Callers holding a typed element convert in Kotlin rather than casting in SQL.
+     *
+     * The key is inlined, see [jsonbField]. This is a correlated subquery per row, so it belongs in a
+     * projection rather than in a predicate. PostgreSQL raises an error if the value is not a jsonb array.
+     */
+    fun jsonbTextArray(field: Field<JSONB>, name: String): Field<List<String>> =
+        DSL.field(
+            "coalesce((select array_agg(elem) from jsonb_array_elements_text({0}->{1}) as t(elem)), '{}')",
+            Array<String>::class.java,
+            field,
+            DSL.inline(name),
+        ).convertFrom { it?.toList() ?: listOf() }
+
     fun jsonbContains(field: Field<JSONB>, value: JSONB): Condition =
         DSL.condition("{0} @> {1}", field, value)
 

--- a/eva-jooq/src/main/kotlin/com/razz/jooq/dsl/DSLs.kt
+++ b/eva-jooq/src/main/kotlin/com/razz/jooq/dsl/DSLs.kt
@@ -1,5 +1,7 @@
 package com.razz.jooq.dsl
 
+import com.razz.jooq.dsl.SqlDSL.eqAny
+import org.jooq.Condition
 import org.jooq.Field
 import org.jooq.JSONB
 import org.jooq.impl.DSL
@@ -8,32 +10,84 @@ import org.jooq.impl.DSL.array
 object ArrayDSL {
 
     fun arrayContains(field: Field<Array<String>>, vararg values: String) =
-        DSL.condition("{0} @> {1}::text[]", field, array(values))
+        DSL.condition("{0} @> {1}::text[]", field, array(*values))
 
-    inline fun <reified T> arrayContains(field: Field<Array<T>>, values: List<T>) =
+    inline fun <reified T> arrayContains(field: Field<Array<T>>, values: Collection<T>) =
         DSL.condition("{0} @> {1}", field, array(*values.toTypedArray()))
 }
 
 object JsonDSL {
 
+    /**
+     * `field->>'name'`, with the key inlined as a SQL literal.
+     *
+     * The key has to be inlined for a btree expression index such as
+     * `CREATE INDEX ... ON t ((refs ->> 'idempotencyKey'))` to be usable. PostgreSQL matches an index
+     * expression against a query expression structurally, and a bind parameter is not a constant. Under a
+     * generic plan, which a pooled connection reaches after five executions with `plan_cache_mode = auto`,
+     * a bound key stays a parameter and the index is silently dropped from consideration.
+     *
+     * Inlining costs one prepared statement and one plan cache entry per distinct key, so callers must pass
+     * keys from a closed set of constants, never keys derived from user input. `DSL.inline` escapes the
+     * literal, so the constraint is plan cache size, not injection safety.
+     *
+     * This accessor is the only place a key gets inlined. Build conditions from it with the jOOQ operators
+     * rather than writing another `{0}->>{1}` template, which is how the bound key kept coming back.
+     */
     fun jsonbField(field: Field<JSONB>, name: String): Field<String> =
         DSL.field("{0}->>{1}", String::class.java, field, DSL.inline(name))
 
-    fun jsonbContainsKeys(field: Field<JSONB>, vararg keys: String) =
-        DSL.condition("jsonb_exists_all({0}, {1}::text[])", field, array(keys))
+    /** `(field->>'name')::int`. The key is inlined, see [jsonbField]. */
+    fun jsonbIntField(field: Field<JSONB>, name: String): Field<Int> =
+        DSL.field("({0}->>{1})::int", Int::class.java, field, DSL.inline(name))
 
-    fun jsonbStringEq(field: Field<JSONB>, name: String, value: String) =
-        DSL.field("{0}->>{1}", String::class.java, field, name).eq(value)
+    /** `field->'jsonKey'->>'textKey'`. Both keys are inlined, see [jsonbField]. */
+    fun jsonbPath(field: Field<JSONB>, jsonKey: String, textKey: String): Field<String> =
+        DSL.field("{0}->{1}->>{2}", String::class.java, field, DSL.inline(jsonKey), DSL.inline(textKey))
 
-    fun jsonbStringValue(field: Field<JSONB>, name: String): Field<String> =
-        DSL.field("{0}->>{1}", String::class.java, field, name)
+    /**
+     * `field->>'name' = value`, with the key inlined and the value bound.
+     *
+     * See [jsonbField] for why the key is inlined. The value stays bound because values are unbounded in
+     * cardinality and usually user derived, so inlining them would flood the plan cache.
+     */
+    fun jsonbStringEq(field: Field<JSONB>, name: String, value: String): Condition =
+        jsonbField(field, name).eq(value)
 
-    fun jsonbContains(field: Field<JSONB>, value: JSONB) =
+    /** `field->>'name'` against a set of values, with the key inlined and the values bound. */
+    fun jsonbStringIn(field: Field<JSONB>, name: String, values: Collection<String>): Condition =
+        jsonbField(field, name).eqAny(values)
+
+    fun jsonbContains(field: Field<JSONB>, value: JSONB): Condition =
         DSL.condition("{0} @> {1}", field, value)
+
+    /**
+     * The keys stay bound. A GIN index extracts its query keys at execution time, so it is unaffected by
+     * the plan caching behaviour described on [jsonbField].
+     */
+    fun jsonbContainsKeys(field: Field<JSONB>, vararg keys: String): Condition =
+        DSL.condition("jsonb_exists_all({0}, {1}::text[])", field, array(*keys))
+
+    /**
+     * True when the jsonb array at `field->'name'` holds any of [values] as a top level string element.
+     *
+     * The key is inlined, see [jsonbField]. The values are bound as a text array, so a value containing a
+     * quote or a backslash is handled by the driver rather than by JSON string building.
+     *
+     * An empty [values] matches nothing, which is what "contains any of none" means. Callers that want an
+     * absent filter to drop out of the condition have to say so themselves.
+     */
+    fun jsonbArrayContainsAny(field: Field<JSONB>, name: String, values: Collection<String>): Condition =
+        DSL.condition(
+            "jsonb_exists_any({0}->{1}, {2}::text[])",
+            field,
+            DSL.inline(name),
+            array(*values.toTypedArray()),
+        )
 }
 
 object SqlDSL {
-    inline fun <reified T> Field<T>.eqAny(values: List<T>) = if (values.size <= 3) {
+    inline fun <reified T> Field<T>.eqAny(values: Collection<T>) = if (values.size <= 3) {
         this.`in`(values)
     } else {
         this.eq(DSL.any(*values.toTypedArray()))
@@ -42,5 +96,21 @@ object SqlDSL {
         this.`in`(*values)
     } else {
         this.eq(DSL.any(*values))
+    }
+
+    /**
+     * `field NOT IN (values) OR field IS NULL`.
+     *
+     * The null branch is deliberate: `NOT IN` on a nullable column drops null rows, which is rarely what
+     * the caller means by "everything except these". The name carries the null inclusion so the caller
+     * does not have to remember it.
+     */
+    inline fun <reified T> Field<T>.notEqAllOrNull(values: Collection<T>): Condition {
+        val condition = if (values.size <= 3) {
+            this.notIn(values)
+        } else {
+            this.notEqual(DSL.all(*values.toTypedArray()))
+        }
+        return condition.or(this.isNull)
     }
 }

--- a/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/JsonDSLTest.kt
+++ b/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/JsonDSLTest.kt
@@ -1,0 +1,65 @@
+package com.razz.jooq.dsl
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotContain
+import org.jooq.JSONB
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+
+class JsonDSLTest : FunSpec({
+
+    val ctx = DSL.using(SQLDialect.POSTGRES)
+    val refs = DSL.field(DSL.name("refs"), JSONB::class.java)
+
+    test("jsonbField inlines the key") {
+        ctx.render(JsonDSL.jsonbField(refs, "idempotencyKey")) shouldBe """"refs"->>'idempotencyKey'"""
+    }
+
+    test("jsonbIntField inlines the key") {
+        ctx.render(JsonDSL.jsonbIntField(refs, "attempt")) shouldBe """("refs"->>'attempt')::int"""
+    }
+
+    test("jsonbPath inlines both keys") {
+        ctx.render(JsonDSL.jsonbPath(refs, "payload", "type")) shouldBe """"refs"->'payload'->>'type'"""
+    }
+
+    test("jsonbStringEq inlines the key so an expression index stays matchable") {
+        ctx.render(JsonDSL.jsonbStringEq(refs, "idempotencyKey", "abc")) shouldBe
+            """"refs"->>'idempotencyKey' = ?"""
+    }
+
+    test("jsonbStringEq keeps the value bound") {
+        ctx.render(JsonDSL.jsonbStringEq(refs, "idempotencyKey", "abc")) shouldNotContain "'abc'"
+    }
+
+    test("jsonbStringEq escapes an inlined key") {
+        ctx.renderInlined(JsonDSL.jsonbStringEq(refs, "' or true --", "abc")) shouldBe
+            """"refs"->>''' or true --' = 'abc'"""
+    }
+
+    test("jsonbStringIn inlines the key and binds the values") {
+        ctx.render(JsonDSL.jsonbStringIn(refs, "clientFlow", listOf("INARI", "OTHER"))) shouldBe
+            """"refs"->>'clientFlow' in (?, ?)"""
+    }
+
+    test("jsonbStringIn switches to = any past three values, keeping one bind") {
+        ctx.render(JsonDSL.jsonbStringIn(refs, "clientFlow", listOf("a", "b", "c", "d"))) shouldBe
+            """"refs"->>'clientFlow' = any (cast(? as varchar[]))"""
+    }
+
+    test("jsonbContainsKeys binds a flat key array") {
+        ctx.render(JsonDSL.jsonbContainsKeys(refs, "a", "b")) shouldBe
+            """(jsonb_exists_all("refs", array[?, ?]::text[]))"""
+    }
+
+    test("jsonbArrayContainsAny inlines the key and binds the values") {
+        ctx.render(JsonDSL.jsonbArrayContainsAny(refs, "tags", listOf("x", "y"))) shouldBe
+            """(jsonb_exists_any("refs"->'tags', array[?, ?]::text[]))"""
+    }
+
+    test("jsonbArrayContainsAny binds a value that would break a JSON literal") {
+        ctx.renderInlined(JsonDSL.jsonbArrayContainsAny(refs, "tags", listOf("""a"]"""))) shouldBe
+            """(jsonb_exists_any("refs"->'tags', array['a"]']::text[]))"""
+    }
+})

--- a/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/JsonDSLTest.kt
+++ b/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/JsonDSLTest.kt
@@ -48,6 +48,12 @@ class JsonDSLTest : FunSpec({
             """"refs"->>'clientFlow' = any (cast(? as varchar[]))"""
     }
 
+    test("jsonbTextArray inlines the key") {
+        ctx.render(JsonDSL.jsonbTextArray(refs, "approvers")) shouldBe
+            "coalesce((select array_agg(elem) from jsonb_array_elements_text(\"refs\"->'approvers') " +
+            "as t(elem)), '{}')"
+    }
+
     test("jsonbContainsKeys binds a flat key array") {
         ctx.render(JsonDSL.jsonbContainsKeys(refs, "a", "b")) shouldBe
             """(jsonb_exists_all("refs", array[?, ?]::text[]))"""

--- a/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/SqlDSLTest.kt
+++ b/eva-jooq/src/test/kotlin/com/razz/jooq/dsl/SqlDSLTest.kt
@@ -1,0 +1,37 @@
+package com.razz.jooq.dsl
+
+import com.razz.jooq.dsl.SqlDSL.eqAny
+import com.razz.jooq.dsl.SqlDSL.notEqAllOrNull
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jooq.SQLDialect
+import org.jooq.impl.DSL
+
+class SqlDSLTest : FunSpec({
+
+    val ctx = DSL.using(SQLDialect.POSTGRES)
+    val state = DSL.field(DSL.name("state"), String::class.java)
+
+    test("eqAny accepts any collection, not only a list") {
+        ctx.render(state.eqAny(setOf("A", "B"))) shouldBe """"state" in (?, ?)"""
+    }
+
+    test("eqAny switches to = any past three values") {
+        ctx.render(state.eqAny(listOf("A", "B", "C", "D"))) shouldBe """"state" = any (cast(? as varchar[]))"""
+    }
+
+    test("notEqAllOrNull keeps null rows") {
+        ctx.render(state.notEqAllOrNull(listOf("A", "B"))) shouldBe
+            """("state" not in (?, ?) or "state" is null)"""
+    }
+
+    test("notEqAllOrNull switches to <> all past three values") {
+        ctx.render(state.notEqAllOrNull(listOf("A", "B", "C", "D"))) shouldBe
+            """("state" <> all (cast(? as varchar[])) or "state" is null)"""
+    }
+
+    test("arrayContains binds a flat array") {
+        val tags = DSL.field(DSL.name("tags"), Array<String>::class.java)
+        ctx.render(ArrayDSL.arrayContains(tags, "a", "b")) shouldBe """("tags" @> array[?, ?]::text[])"""
+    }
+})

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -42,9 +42,13 @@ import org.jooq.exception.SQLStateClass.C40_TRANSACTION_ROLLBACK
 import org.jooq.impl.SQLDataType
 import org.jooq.postgres.extensions.types.Inet
 import java.io.IOException
+import java.sql.Date
+import java.sql.Time
+import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.ZoneOffset.UTC
 
 class VertxQueryExecutor(
@@ -116,11 +120,37 @@ class VertxQueryExecutor(
                 else -> {
                     @Suppress("UNCHECKED_CAST")
                     val converter = bound.converter as Converter<Any, Any>
-                    converter.to(value)
+                    // A forced type such as com.razz.jooq.converter.InstantConverter targets JDBC, so it
+                    // hands back a java.sql temporal that the vertx pg client cannot encode. The branches
+                    // above cover the same types arriving without a converter; everything converted has to
+                    // be mapped across here instead. Arrays land here too.
+                    javaTimeValue(converter.to(value))
                 }
             }
         },
     )
+
+    private fun javaTimeValue(value: Any?): Any? = when (value) {
+        is Timestamp -> value.toLocalDateTime()
+        is Date -> value.toLocalDate()
+        is Time -> value.toLocalTime()
+        is Array<*> -> value.javaTimeArray()
+        else -> value
+    }
+
+    private fun Array<*>.javaTimeArray(): Any {
+        // Vertx resolves an array encoder by the array's own class, not by its elements, so the result
+        // has to carry the java.time component type and not merely hold remapped elements.
+        val component = when (this::class.java.componentType) {
+            Timestamp::class.java -> LocalDateTime::class.java
+            Date::class.java -> LocalDate::class.java
+            Time::class.java -> LocalTime::class.java
+            else -> return this
+        }
+        val remapped = java.lang.reflect.Array.newInstance(component, size)
+        forEachIndexed { index, element -> java.lang.reflect.Array.set(remapped, index, javaTimeValue(element)) }
+        return remapped
+    }
 
     private fun <R : Record> convertRowToRecord(
         dslContext: DSLContext,

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTemporalSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTemporalSpec.kt
@@ -1,0 +1,130 @@
+package com.razz.eva.persistence.vertx.executor
+
+import com.razz.eva.persistence.vertx.PgPoolConnectionProvider
+import com.razz.eva.persistence.vertx.VertxConnectionElement
+import com.razz.eva.persistence.vertx.VertxTransactionManager
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.vertx.core.Future.succeededFuture
+import io.vertx.pgclient.PgConnection
+import io.vertx.sqlclient.PreparedQuery
+import io.vertx.sqlclient.Row
+import io.vertx.sqlclient.RowSet
+import io.vertx.sqlclient.impl.ListTuple
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jooq.Condition
+import org.jooq.Converter
+import org.jooq.Record
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+import java.sql.Date
+import java.sql.Timestamp
+import java.time.Instant
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneOffset.UTC
+import java.util.function.Function
+
+/** Mirrors com.razz.jooq.converter.LocalDateConverter, which eva-persistence-vertx cannot depend on. */
+private class SqlDateConverter : Converter<Date, LocalDate> {
+    override fun from(databaseObject: Date?): LocalDate? = databaseObject?.toLocalDate()
+    override fun to(userObject: LocalDate?): Date? = userObject?.let(Date::valueOf)
+    override fun fromType(): Class<Date> = Date::class.java
+    override fun toType(): Class<LocalDate> = LocalDate::class.java
+}
+
+/** Mirrors com.razz.jooq.converter.InstantConverter. */
+private class SqlTimestampConverter : Converter<Timestamp, Instant> {
+    override fun from(databaseObject: Timestamp?): Instant? = databaseObject?.toLocalDateTime()?.toInstant(UTC)
+    override fun to(userObject: Instant?): Timestamp? =
+        userObject?.let { Timestamp.valueOf(LocalDateTime.ofInstant(it, UTC)) }
+    override fun fromType(): Class<Timestamp> = Timestamp::class.java
+    override fun toType(): Class<Instant> = Instant::class.java
+}
+
+private val temporalTable = object : TableImpl<Record>(DSL.name("temporal_test")) {
+    val DAY = createField(DSL.name("day"), SQLDataType.DATE.asConvertedDataType(SqlDateConverter()))!!
+    val AT = createField(DSL.name("at"), SQLDataType.TIMESTAMP.asConvertedDataType(SqlTimestampConverter()))!!
+}
+
+class VertxQueryExecutorTemporalSpec : ShouldSpec({
+
+    val dslContext = DSL.using(POSTGRES)
+    val connectionProvider = mockk<PgPoolConnectionProvider>(relaxed = true)
+    val transactionManager = spyk(VertxTransactionManager(connectionProvider, connectionProvider))
+    val executor = VertxQueryExecutor(transactionManager)
+
+    val paramsSlot = slot<ListTuple>()
+
+    val preparedQueryMock = mockk<PreparedQuery<RowSet<Row>>> {
+        every { mapping(any<Function<Row, Any>>()) } answers {
+            mockk {
+                every { execute(capture(paramsSlot)) } returns succeededFuture(
+                    mockk {
+                        every { iterator() } answers {
+                            mockk { every { hasNext() } returns false }
+                        }
+                        every { size() } returns 0
+                    },
+                )
+            }
+        }
+    }
+
+    val connection = mockk<PgConnection>(relaxed = true) {
+        every { preparedQuery(any()) } answers { preparedQueryMock }
+    }
+    coEvery { connectionProvider.acquire() } coAnswers { connection }
+
+    suspend fun boundValue(condition: Condition): Any? {
+        clearMocks(connection, answers = false)
+        every { connection.preparedQuery(any()) } answers { preparedQueryMock }
+        withContext(Dispatchers.IO + VertxConnectionElement(connection)) {
+            executor.executeSelect(dslContext, dslContext.selectFrom(temporalTable).where(condition), temporalTable)
+        }
+        return paramsSlot.captured.getValue(0)
+    }
+
+    should("bind a date array as a LocalDate array") {
+        val days = listOf(
+            LocalDate.parse("2026-08-10"),
+            LocalDate.parse("2026-08-11"),
+            LocalDate.parse("2026-08-12"),
+            LocalDate.parse("2026-08-13"),
+        )
+        val bound = boundValue(temporalTable.DAY.eq(DSL.any(*days.toTypedArray())))
+        bound!!::class.java shouldBe Array<LocalDate>::class.java
+        (bound as Array<*>).toList() shouldBe days
+    }
+
+    should("bind a timestamp array as a LocalDateTime array") {
+        val moments = listOf(
+            Instant.parse("2026-08-10T10:15:30Z"),
+            Instant.parse("2026-08-11T10:15:30Z"),
+            Instant.parse("2026-08-12T10:15:30Z"),
+            Instant.parse("2026-08-13T10:15:30Z"),
+        )
+        val bound = boundValue(temporalTable.AT.eq(DSL.any(*moments.toTypedArray())))
+        bound!!::class.java shouldBe Array<LocalDateTime>::class.java
+        (bound as Array<*>).toList() shouldBe moments.map { LocalDateTime.ofInstant(it, UTC) }
+    }
+
+    should("keep binding a single date as a LocalDate") {
+        val day = LocalDate.parse("2026-08-13")
+        boundValue(temporalTable.DAY.eq(day)) shouldBe day
+    }
+
+    should("keep binding a single instant as a LocalDateTime") {
+        val moment = Instant.parse("2026-08-13T10:15:30Z")
+        boundValue(temporalTable.AT.eq(moment)) shouldBe LocalDateTime.ofInstant(moment, UTC)
+    }
+})


### PR DESCRIPTION
`JsonDSL` built the same `refs ->> 'key'` expression three ways. `jsonbField` inlined the key, `jsonbStringEq` and `jsonbStringValue` bound it.

A btree expression index is declared over a literal, so a bound key matches it only while PostgreSQL keeps the statement on a custom plan, where parameters are folded to constants at planning time. After five executions with `plan_cache_mode = auto` a pooled connection switches that statement to a generic plan, the `Param` node stops equalling the index's `Const`, and the index is silently dropped from consideration. The failure arrives with load and says nothing in the logs.

Measured on PostgreSQL 17, 200k rows, one `((refs ->> 'idempotencyKey'))` index, same prepared statement, only `plan_cache_mode` changed:

| statement | plan mode | plan | cost |
| --- | --- | --- | --- |
| `refs ->> $1 = $2` | custom | Index Scan | 8.44 |
| `refs ->> $1 = $2` | generic | Parallel Seq Scan | 5624.30 |
| `refs ->> 'idempotencyKey' = $1` | generic | Index Scan | 8.44 |

The key is now inlined in exactly one place, `jsonbField`, and conditions are built from that accessor with the jOOQ operators instead of re-typing the `{0}->>{1}` template, which is how the bound key kept coming back. Values stay bound, since they are unbounded in cardinality and usually user derived. Inlining keys means callers have to pass them from a closed set of constants, which the KDoc now states.

Also here:

`jsonbContainsKeys` and `ArrayDSL.arrayContains` passed a Kotlin array to a Java vararg without the spread, so they built a nested array, `array[cast(? as varchar[])]::text[]`. PostgreSQL flattens on element iteration, so both worked by accident. They are flat now.

`jsonbStringValue` is dropped, it was an exact alias of `jsonbField`.

New helpers: `jsonbIntField`, `jsonbPath`, `jsonbTextArray`, `jsonbStringIn`, `jsonbArrayContainsAny` and `SqlDSL.notEqAllOrNull`. `jsonbArrayContainsAny` builds `jsonb_exists_any` with the values bound, so a value holding a quote or a backslash is the driver's problem rather than JSON string building, and an empty value list matches nothing. `notEqAllOrNull` carries the null branch in its name because `NOT IN` on a nullable column drops null rows.

`jsonbTextArray` reads a jsonb array as a text list and coalesces an absent key and an empty array to the same empty list, so callers convert to their element type in Kotlin rather than casting in SQL.

`eqAny` and `arrayContains` take a `Collection` rather than a `List`.

Breaking: callers of `jsonbStringValue` move to `jsonbField`.
