### PR TITLE
Spike: carry the pool on the connection

### DIFF
--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcConnectionElement.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcConnectionElement.kt
@@ -1,12 +1,15 @@
 package com.razz.eva.persistence.jdbc
 
+import com.razz.eva.persistence.Connected
 import com.razz.eva.persistence.ConnectionWrapper
 import java.sql.Connection
 import kotlin.coroutines.CoroutineContext
 
 internal class JdbcConnectionElement(
-    internal val connection: Connection,
+    internal val connected: Connected<Connection>,
 ) : ConnectionWrapper<Connection> {
+
+    private val connection: Connection get() = connected.value
 
     private val initialAutoCommit = connection.autoCommit
 

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManager.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/JdbcTransactionManager.kt
@@ -2,6 +2,7 @@ package com.razz.eva.persistence.jdbc
 
 import com.razz.eva.persistence.ConnectionMode
 import com.razz.eva.persistence.ConnectionProvider
+import com.razz.eva.persistence.Connected
 import com.razz.eva.persistence.ConnectionWrapper
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.tracing.getEvaMeter
@@ -31,7 +32,7 @@ class JdbcTransactionManager(
         ?.setExplicitBucketBoundariesAdvice(DISPATCH_WAIT_BUCKET_BOUNDARIES_NANOS)
         ?.build()
 
-    override suspend fun <R> withConnection(block: suspend (Connection) -> R): R {
+    override suspend fun <R> withConnection(block: suspend (Connected<Connection>) -> R): R {
         val scheduledAt = System.nanoTime()
         return withContext(blockingJdbcContext) {
             recordDispatchWait(scheduledAt, WITH_CONNECTION)
@@ -39,7 +40,7 @@ class JdbcTransactionManager(
         }
     }
 
-    override suspend fun <R> inTransaction(mode: ConnectionMode, block: suspend (Connection) -> R): R {
+    override suspend fun <R> inTransaction(mode: ConnectionMode, block: suspend (Connected<Connection>) -> R): R {
         val scheduledAt = System.nanoTime()
         return withContext(blockingJdbcContext) {
             recordDispatchWait(scheduledAt, IN_TRANSACTION)
@@ -54,11 +55,11 @@ class JdbcTransactionManager(
         )
     }
 
-    override fun wrapConnection(newConn: Connection): ConnectionWrapper<Connection> =
-        JdbcConnectionElement(newConn)
+    override fun wrapConnection(connected: Connected<Connection>): ConnectionWrapper<Connection> =
+        JdbcConnectionElement(connected)
 
-    override suspend fun ctxConnection(): Connection? =
-        coroutineContext[JdbcConnectionElement]?.connection
+    override suspend fun ctxConnection(): Connected<Connection>? =
+        coroutineContext[JdbcConnectionElement]?.connected
 
     override fun supportsPipelining(): Boolean = false
 

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -14,13 +14,13 @@ import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
-import com.razz.eva.persistence.AcquiredEndpoint
 import com.razz.eva.persistence.executor.QueryExecutor.Companion.operationName
 import com.razz.eva.persistence.executor.QueryExecutor.Companion.queryTarget
 import com.razz.eva.tracing.DatabaseSpans
 import com.razz.eva.tracing.DatabaseSpans.setServer
 import com.razz.eva.tracing.use
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.OpenTelemetry.noop
 import kotlinx.coroutines.withContext
 import org.jooq.DMLQuery
@@ -40,6 +40,7 @@ import org.jooq.exception.SQLStateClass.C40_TRANSACTION_ROLLBACK
 import org.jooq.impl.DSL
 import org.postgresql.util.PSQLException
 import java.sql.Connection
+import kotlin.coroutines.EmptyCoroutineContext
 
 class JdbcQueryExecutor(
     private val transactionManager: TransactionManager<Connection>,
@@ -52,8 +53,10 @@ class JdbcQueryExecutor(
         table: Table<R>,
     ): List<R> {
         val sql = dslContext.render(jooqQuery)
-        return traced(jooqQuery, table, sql) {
-            transactionManager.withConnection { connection ->
+        return traced(jooqQuery, table, sql) { span ->
+            transactionManager.withConnection { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 dslContext.using(connection).preparedQuery(sql, jooqQuery).coerce(table).fetch()
             }
         }
@@ -70,8 +73,10 @@ class JdbcQueryExecutor(
         // for both the span attribute and the execution.
         if (fields == null) jooqQuery.setReturning() else jooqQuery.setReturning(fields)
         val sql = dslContext.render(jooqQuery)
-        return traced(jooqQuery, table, sql) {
-            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+        return traced(jooqQuery, table, sql) { span ->
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 val prepared = dslContext.using(connection).preparedQuery(sql, jooqQuery)
                 if (fields == null) {
                     prepared.coerce(table).fetch()
@@ -87,8 +92,10 @@ class JdbcQueryExecutor(
         jooqQuery: DMLQuery<R>,
     ): Int {
         val sql = dslContext.render(jooqQuery)
-        return traced(jooqQuery, null, sql) {
-            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+        return traced(jooqQuery, null, sql) { span ->
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 dslContext.using(connection).run {
                     execute(sql, *bindValues(jooqQuery))
                 }
@@ -173,17 +180,14 @@ class JdbcQueryExecutor(
         jooqQuery: Query,
         table: Table<*>?,
         sql: String,
-        block: suspend () -> T,
+        block: suspend (Span?) -> T,
     ): T {
         if (!DatabaseSpans.tracing()) {
-            return block()
+            return block(null)
         }
-        val acquired = AcquiredEndpoint()
-        // The span is built inside withContext, not before it: withContext runs ensureActive first, so a
-        // span created outside would never be ended for a call cancelled before it starts. The manager fills
-        // the slot as it goes to a pool, and span.use makes the span current, which is what nests the
-        // connection acquisition spans underneath it and records failure on it.
-        return withContext(acquired) {
+        // The span is built inside withContext, because withContext runs ensureActive first and a span
+        // built outside it would never end for a call cancelled before it starts.
+        return withContext(EmptyCoroutineContext) {
             val span = DatabaseSpans.querySpan(
                 openTelemetry = openTelemetry,
                 operation = operationName(jooqQuery),
@@ -191,13 +195,7 @@ class JdbcQueryExecutor(
                 sql = sql,
             )
             span.use {
-                try {
-                    block()
-                } finally {
-                    acquired.endpoint?.let { endpoint ->
-                        span.setServer(endpoint.address, endpoint.port, endpoint.database, acquired.role?.name)
-                    }
-                }
+                block(span)
             }
         }
     }

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/VertxConnectionElement.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/VertxConnectionElement.kt
@@ -1,5 +1,6 @@
 package com.razz.eva.persistence.vertx
 
+import com.razz.eva.persistence.Connected
 import com.razz.eva.persistence.ConnectionWrapper
 import io.vertx.kotlin.coroutines.coAwait
 import io.vertx.pgclient.PgConnection
@@ -7,8 +8,10 @@ import io.vertx.sqlclient.Transaction
 import kotlin.coroutines.CoroutineContext
 
 internal class VertxConnectionElement(
-    internal val connection: PgConnection,
+    internal val connected: Connected<PgConnection>,
 ) : ConnectionWrapper<PgConnection> {
+
+    private val connection: PgConnection get() = connected.value
 
     private var transaction: Transaction? = null
 

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/VertxTransactionManager.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/VertxTransactionManager.kt
@@ -1,5 +1,6 @@
 package com.razz.eva.persistence.vertx
 
+import com.razz.eva.persistence.Connected
 import com.razz.eva.persistence.ConnectionProvider
 import com.razz.eva.persistence.ConnectionWrapper
 import com.razz.eva.persistence.TransactionManager
@@ -11,11 +12,11 @@ class VertxTransactionManager(
     replicaProvider: ConnectionProvider<PgConnection>,
 ) : TransactionManager<PgConnection>(primaryProvider, replicaProvider) {
 
-    override fun wrapConnection(newConn: PgConnection): ConnectionWrapper<PgConnection> =
-        VertxConnectionElement(newConn)
+    override fun wrapConnection(connected: Connected<PgConnection>): ConnectionWrapper<PgConnection> =
+        VertxConnectionElement(connected)
 
-    override suspend fun ctxConnection(): PgConnection? =
-        coroutineContext[VertxConnectionElement]?.connection
+    override suspend fun ctxConnection(): Connected<PgConnection>? =
+        coroutineContext[VertxConnectionElement]?.connected
 
     override fun supportsPipelining(): Boolean = true
 }

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -11,7 +11,6 @@ import com.razz.eva.persistence.PersistenceException.UniqueModelRecordViolationE
 import com.razz.eva.persistence.TransactionManager
 import com.razz.eva.persistence.executor.QueryExecutor
 import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
-import com.razz.eva.persistence.AcquiredEndpoint
 import com.razz.eva.persistence.executor.QueryExecutor.Companion.operationName
 import com.razz.eva.persistence.executor.QueryExecutor.Companion.queryTarget
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
@@ -21,6 +20,7 @@ import com.razz.eva.tracing.use
 import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.OpenTelemetry.noop
 import io.vertx.core.json.Json
 import io.vertx.kotlin.coroutines.coAwait
@@ -59,6 +59,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneOffset.UTC
+import kotlin.coroutines.EmptyCoroutineContext
 
 class VertxQueryExecutor(
     private val transactionManager: TransactionManager<PgConnection>,
@@ -71,8 +72,10 @@ class VertxQueryExecutor(
         table: Table<R>,
     ): List<R> {
         val sql = dslContext.renderNamedParams(jooqQuery)
-        return traced(jooqQuery, table, sql) {
-            transactionManager.withConnection { connection ->
+        return traced(jooqQuery, table, sql) { span ->
+            transactionManager.withConnection { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 val rows = executeQuery(connection, dslContext, jooqQuery, sql, table.fields(), table)
                 rows.toList()
             }
@@ -96,8 +99,10 @@ class VertxQueryExecutor(
             matched.toTypedArray()
         }
         val sql = dslContext.renderNamedParams(jooqQuery)
-        return traced(jooqQuery, table, sql) {
-            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+        return traced(jooqQuery, table, sql) { span ->
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 val rows = executeQuery(connection, dslContext, jooqQuery, sql, fields, table)
                 rows.toList()
             }
@@ -109,8 +114,10 @@ class VertxQueryExecutor(
         jooqQuery: DMLQuery<R>,
     ): Int {
         val sql = dslContext.renderNamedParams(jooqQuery)
-        return traced(jooqQuery, null, sql) {
-            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+        return traced(jooqQuery, null, sql) { span ->
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connected ->
+                span?.setServer(connected.endpoint.address, connected.endpoint.port, connected.endpoint.database, connected.role?.name)
+                val connection = connected.value
                 connection.preparedQuery(sql)
                     .execute(bindParams(dslContext, jooqQuery)).map(SqlResult<*>::rowCount).coAwait()
             }
@@ -132,17 +139,14 @@ class VertxQueryExecutor(
         jooqQuery: Query,
         table: Table<*>?,
         sql: String,
-        block: suspend () -> T,
+        block: suspend (Span?) -> T,
     ): T {
         if (!DatabaseSpans.tracing()) {
-            return block()
+            return block(null)
         }
-        val acquired = AcquiredEndpoint()
-        // The span is built inside withContext, not before it: withContext runs ensureActive first, so a
-        // span created outside would never be ended for a call cancelled before it starts. The manager fills
-        // the slot as it goes to a pool, and span.use makes the span current, which is what nests the
-        // connection acquisition spans underneath it and records failure on it.
-        return withContext(acquired) {
+        // The span is built inside withContext, because withContext runs ensureActive first and a span
+        // built outside it would never end for a call cancelled before it starts.
+        return withContext(EmptyCoroutineContext) {
             val span = DatabaseSpans.querySpan(
                 openTelemetry = openTelemetry,
                 operation = operationName(jooqQuery),
@@ -150,13 +154,7 @@ class VertxQueryExecutor(
                 sql = sql,
             )
             span.use {
-                try {
-                    block()
-                } finally {
-                    acquired.endpoint?.let { endpoint ->
-                        span.setServer(endpoint.address, endpoint.port, endpoint.database, acquired.role?.name)
-                    }
-                }
+                block(span)
             }
         }
     }

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/Connected.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/Connected.kt
@@ -1,0 +1,17 @@
+package com.razz.eva.persistence
+
+/**
+ * A connection and the facts about where it came from.
+ *
+ * The transaction manager builds this when it takes a connection from a pool, so the facts travel with the
+ * connection instead of through a side channel. A statement that reuses a connection from the coroutine
+ * context reads the same facts, so it reports the pool that opened the connection.
+ *
+ * This is the place to hang anything else that describes one connection, for example the thread that holds
+ * it or the time the pool took to give it.
+ */
+data class Connected<C>(
+    val value: C,
+    val endpoint: DbEndpoint,
+    val role: PoolRole?,
+)

--- a/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
+++ b/eva-persistence/src/main/kotlin/com/razz/eva/persistence/TransactionManager.kt
@@ -13,47 +13,41 @@ abstract class TransactionManager<C>(
     private val replicaProvider: ConnectionProvider<C>,
 ) {
 
-    open suspend fun <R> withConnection(block: suspend (C) -> R): R {
+    open suspend fun <R> withConnection(block: suspend (Connected<C>) -> R): R {
         return when (val existingConn = ctxConnection()) {
             null -> {
                 val provider = connectionProvider(currentCoroutineContext())
                 var newConn: C? = null
                 try {
-                    recordPool(provider)
                     newConn = acquire(provider)
                     currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
-                    block(newConn)
+                    block(connected(newConn, provider))
                 } finally {
                     newConn?.let { provider.release(it) }
                 }
             }
-            else -> {
-                // A context connection can only have been opened by inTransaction, which always acquires
-                // from the primary, so this holds by construction. Without it every statement
-                // after the first in a transaction would report no pool at all.
-                recordPool(primaryProvider)
-                block(existingConn)
-            }
+            // The reused connection carries the pool that opened it, so a statement inside a
+            // transaction reports the truth and not an assumption about which pool that was.
+            else -> block(existingConn)
         }
     }
 
     open suspend fun <R> inTransaction(
         mode: ConnectionMode,
-        block: suspend (C) -> R,
+        block: suspend (Connected<C>) -> R,
     ): R {
         return when (val existingConn = ctxConnection()) {
             null -> {
                 check(mode == REQUIRE_NEW) { "Required existing connection but no existing connection was found" }
                 var newConn: C? = null
                 try {
-                    recordPool(primaryProvider)
                     newConn = acquire(primaryProvider)
                     currentCoroutineContext()[ConnectionAcquisitionCounter]?.increment()
-                    val ctx = wrapConnection(newConn)
+                    val ctx = wrapConnection(connected(newConn, primaryProvider))
                     withContext(ctx) {
                         try {
                             ctx.begin()
-                            val result = block(newConn)
+                            val result = block(connected(newConn, primaryProvider))
                             ctx.commit()
                             result
                         } catch (ex: Exception) {
@@ -71,29 +65,24 @@ abstract class TransactionManager<C>(
             // and will be handled there
             else -> {
                 check(mode == REQUIRE_EXISTING) { "Required new connection but existing connection was found" }
-                recordPool(primaryProvider)
                 block(existingConn)
             }
         }
     }
 
     /**
-     * The role comes from which constructor argument the provider was passed as, so a provider mislabelling
-     * itself cannot mislabel a span. Where both pools are the same instance the answer is PRIMARY, which is
-     * honest: there is one pool. A provider that is neither gets no role. Its address remains.
+     * The role comes from which constructor argument the provider was passed as, so a provider mislabeling
+     * itself cannot mislabel a span. A provider that is neither pool gets no role. Its address remains.
      */
-    protected suspend fun recordPool(provider: ConnectionProvider<C>) {
-        // Nothing asked, so the provider is not even consulted for its endpoint.
-        val slot = currentCoroutineContext()[AcquiredEndpoint] ?: return
-        val role = when {
+    private fun connected(conn: C, provider: ConnectionProvider<C>) = Connected(
+        value = conn,
+        endpoint = provider.endpoint,
+        role = when {
             provider === primaryProvider -> PoolRole.PRIMARY
             provider === replicaProvider -> PoolRole.REPLICA
-            // A subclass may wrap its providers or hold a third. Reporting no role beats reporting the
-            // wrong one, and the address still says where the call went.
             else -> null
-        }
-        slot.record(provider.endpoint, role)
-    }
+        },
+    )
 
     private suspend fun acquire(provider: ConnectionProvider<C>): C = try {
         provider.acquire()
@@ -112,7 +101,7 @@ abstract class TransactionManager<C>(
 
     abstract fun supportsPipelining(): Boolean
 
-    protected abstract fun wrapConnection(newConn: C): ConnectionWrapper<C>
+    protected abstract fun wrapConnection(connected: Connected<C>): ConnectionWrapper<C>
 
-    protected abstract suspend fun ctxConnection(): C?
+    protected abstract suspend fun ctxConnection(): Connected<C>?
 }

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpans.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpans.kt
@@ -50,6 +50,16 @@ object DatabaseSpans {
      * unset when no pool was reached, since an absent address is honest where a guessed one is not. A pool
      * the manager cannot name keeps its address and omits the role only.
      */
+    fun Span.setServer(server: DbServer) = setServer(server.address, server.port, server.database, server.role)
+
+    /** What a span reports about the pool that served a call. */
+    interface DbServer {
+        val address: String
+        val port: Int
+        val database: String
+        val role: String?
+    }
+
     fun Span.setServer(address: String, port: Int, database: String, role: String?) {
         setAttribute("server.address", address)
         setAttribute("server.port", port.toLong())


### PR DESCRIPTION
This is a spike. Do not merge it. It asks whether the pool can travel on the connection, and not through the `AcquiredEndpoint` context slot.

It can, and it buys nothing. A hostile review found that both designs write the same attributes on all four paths. The base branch is already correct when a statement reuses a connection. `inTransaction` is the only code that puts a connection into the context, and it always opens a primary connection. The one behavioral difference runs the other way. This branch has no `Connected` for a call that never gets a connection, so it reports no pool for a failed acquire.

A manager that puts a replica connection into the context motivated the spike. No such manager exists in eva. This branch does not fix that case either. A subclass that overrides `inTransaction` builds its own `Connected`, and `Connected` is a public data class, so the subclass can state any pool.

The branch also costs more than the base. Four signatures change shape on a class that consumers subclass, and `eva-persistence:compileTestFixturesKotlin` fails. Test fixtures are a published artifact.

Close this. The criticism that led to it was right about the shape of `AcquiredEndpoint`, and razz-team/eva#307 acts on that. Report at `/tmp/eva-db-span-assessment-5.md`.
