### PR TITLE
Bind temporal arrays by the scalar rules

### DIFF
--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -117,6 +117,15 @@ class VertxQueryExecutor(
                 is Instant -> LocalDateTime.ofInstant(value, UTC)
                 is LocalDate -> value
                 is Inet -> io.vertx.pgclient.data.Inet().setAddress(value.address()).setNetmask(value.prefix())
+                // Arrays of the types handled above bypass the converter too. Going through it and mapping
+                // back would agree with the scalar branches only for a converter that round trips a wall
+                // clock, as com.razz.jooq.converter.InstantConverter does. One built on Timestamp.from
+                // would disagree by the JVM offset.
+                is Array<*> -> value.nativeArray() ?: run {
+                    @Suppress("UNCHECKED_CAST")
+                    val converter = bound.converter as Converter<Any, Any>
+                    javaTimeValue(converter.to(value))
+                }
                 else -> {
                     @Suppress("UNCHECKED_CAST")
                     val converter = bound.converter as Converter<Any, Any>
@@ -130,6 +139,15 @@ class VertxQueryExecutor(
         },
     )
 
+    // Elements mapped by the same rule the scalar branches use, or null when the component type is not one
+    // of those and the jOOQ converter has to run instead.
+    private fun Array<*>.nativeArray(): Any? = when (this::class.java.componentType) {
+        Instant::class.java -> Array(size) { i -> (this[i] as Instant?)?.let { LocalDateTime.ofInstant(it, UTC) } }
+        LocalDate::class.java -> this
+        LocalDateTime::class.java -> this
+        else -> null
+    }
+
     private fun javaTimeValue(value: Any?): Any? = when (value) {
         is Timestamp -> value.toLocalDateTime()
         is Date -> value.toLocalDate()
@@ -139,17 +157,27 @@ class VertxQueryExecutor(
     }
 
     private fun Array<*>.javaTimeArray(): Any {
-        // Vertx resolves an array encoder by the array's own class, not by its elements, so the result
-        // has to carry the java.time component type and not merely hold remapped elements.
-        val component = when (this::class.java.componentType) {
-            Timestamp::class.java -> LocalDateTime::class.java
-            Date::class.java -> LocalDate::class.java
-            Time::class.java -> LocalTime::class.java
-            else -> return this
-        }
+        // Vertx resolves an array encoder by the array's own class, not by its elements, so the result has to
+        // carry the java.time component type. The component type is matched exactly, so an Object[] or a
+        // java.util.Date[] holding java.sql values falls back to the elements.
+        val component = componentTarget() ?: elementTarget() ?: return this
         val remapped = java.lang.reflect.Array.newInstance(component, size)
         forEachIndexed { index, element -> java.lang.reflect.Array.set(remapped, index, javaTimeValue(element)) }
         return remapped
+    }
+
+    private fun Array<*>.componentTarget(): Class<*>? = when (this::class.java.componentType) {
+        Timestamp::class.java -> LocalDateTime::class.java
+        Date::class.java -> LocalDate::class.java
+        Time::class.java -> LocalTime::class.java
+        else -> null
+    }
+
+    private fun Array<*>.elementTarget(): Class<*>? = when (firstOrNull { it != null }) {
+        is Timestamp -> LocalDateTime::class.java
+        is Date -> LocalDate::class.java
+        is Time -> LocalTime::class.java
+        else -> null
     }
 
     private fun <R : Record> convertRowToRecord(

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTemporalSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTemporalSpec.kt
@@ -27,10 +27,12 @@ import org.jooq.impl.DSL
 import org.jooq.impl.SQLDataType
 import org.jooq.impl.TableImpl
 import java.sql.Date
+import java.sql.Time
 import java.sql.Timestamp
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.ZoneOffset.UTC
 import java.util.function.Function
 
@@ -40,6 +42,13 @@ private class SqlDateConverter : Converter<Date, LocalDate> {
     override fun to(userObject: LocalDate?): Date? = userObject?.let(Date::valueOf)
     override fun fromType(): Class<Date> = Date::class.java
     override fun toType(): Class<LocalDate> = LocalDate::class.java
+}
+
+private class SqlTimeConverter : Converter<Time, LocalTime> {
+    override fun from(databaseObject: Time?): LocalTime? = databaseObject?.toLocalTime()
+    override fun to(userObject: LocalTime?): Time? = userObject?.let(Time::valueOf)
+    override fun fromType(): Class<Time> = Time::class.java
+    override fun toType(): Class<LocalTime> = LocalTime::class.java
 }
 
 /** Mirrors com.razz.jooq.converter.InstantConverter. */
@@ -54,6 +63,7 @@ private class SqlTimestampConverter : Converter<Timestamp, Instant> {
 private val temporalTable = object : TableImpl<Record>(DSL.name("temporal_test")) {
     val DAY = createField(DSL.name("day"), SQLDataType.DATE.asConvertedDataType(SqlDateConverter()))!!
     val AT = createField(DSL.name("at"), SQLDataType.TIMESTAMP.asConvertedDataType(SqlTimestampConverter()))!!
+    val AT_TIME = createField(DSL.name("at_time"), SQLDataType.TIME.asConvertedDataType(SqlTimeConverter()))!!
 }
 
 class VertxQueryExecutorTemporalSpec : ShouldSpec({
@@ -116,6 +126,26 @@ class VertxQueryExecutorTemporalSpec : ShouldSpec({
         val bound = boundValue(temporalTable.AT.eq(DSL.any(*moments.toTypedArray())))
         bound!!::class.java shouldBe Array<LocalDateTime>::class.java
         (bound as Array<*>).toList() shouldBe moments.map { LocalDateTime.ofInstant(it, UTC) }
+    }
+
+    should("bind a timestamp array holding a null") {
+        val moments = arrayOf(Instant.parse("2026-08-10T10:15:30Z"), null, Instant.parse("2026-08-12T10:15:30Z"))
+        val bound = boundValue(temporalTable.AT.eq(DSL.any(*moments)))
+        bound!!::class.java shouldBe Array<LocalDateTime>::class.java
+        (bound as Array<*>).toList() shouldBe listOf(
+            LocalDateTime.parse("2026-08-10T10:15:30"),
+            null,
+            LocalDateTime.parse("2026-08-12T10:15:30"),
+        )
+    }
+
+    should("bind a time array through the converter route") {
+        // The converter hands back java.sql.Time[], which has to be mapped. Throwing on it or
+        // passed through: vertx cannot encode it.
+        val times = listOf(LocalTime.parse("10:15:30"), LocalTime.parse("11:15:30"))
+        val bound = boundValue(temporalTable.AT_TIME.eq(DSL.any(*times.toTypedArray())))
+        bound!!::class.java shouldBe Array<LocalTime>::class.java
+        (bound as Array<*>).toList() shouldBe times
     }
 
     should("keep binding a single date as a LocalDate") {


### PR DESCRIPTION
The vertx executor binds an array of temporal values through the jOOQ converter, which returns a `java.sql` array. The vertx pg client cannot encode one. `eqAny` over a date or a timestamp column fails past three values, where jOOQ switches from an `in` list to `= any(array)`.

Released in 0.36.0. This is the fix on its own, for 0.36.1.

An array of `Instant`, `LocalDate` or `LocalDateTime` now maps from the user value by the same rules the executor applies to a single value, so the result does not depend on how a converter treats time zones. Null elements survive. An array that the converter still handles, such as `java.sql.Time[]`, maps by component type. An `Object[]` or a `java.util.Date[]` holding `java.sql` values maps by element.

`VertxQueryExecutorTemporalSpec` covers the array cases, the null element, and the converter route through a `Converter<Time, LocalTime>`, which `nativeArray` does not intercept.

This is a subset of razz-team/eva#304. It carries no span changes.
