### PR TITLE
Name database spans, cap the statement, and trace the live test engines

### DIFF
--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
@@ -1,0 +1,48 @@
+package com.razz.eva.tracing
+
+import org.jooq.Delete
+import org.jooq.Insert
+import org.jooq.Merge
+import org.jooq.Query
+import org.jooq.Select
+import org.jooq.Update
+import org.jooq.impl.QOM
+
+/**
+ * Names for a database span, taken from the jOOQ query object.
+ *
+ * The semantic conventions ask for `{db.operation.name} {target}`. A constant name puts every database call
+ * in one span metric bucket, and the table set bounds the cardinality of this one.
+ */
+object QueryNaming {
+
+    fun operationName(jooqQuery: Query?): String = when (jooqQuery) {
+        is Select<*> -> "SELECT"
+        is Insert<*> -> "INSERT"
+        is Update<*> -> "UPDATE"
+        is Delete<*> -> "DELETE"
+        is Merge<*> -> "MERGE"
+        else -> "QUERY"
+    }
+
+    /**
+     * The table a statement targets. Matches the DSL forms as well as the query objects: `deleteFrom(t)` is
+     * a [QOM.Delete] and not a `DeleteQuery`, so matching only the latter would name nothing at all.
+     *
+     * A merge upsert returns null. `org.jooq.impl.MergeUpsert` implements [Merge] and not [QOM.Merge].
+     */
+    fun queryTarget(jooqQuery: Query?): String? = when (jooqQuery) {
+        is QOM.Insert<*> -> jooqQuery.`$into`()?.name
+        is QOM.Update<*> -> jooqQuery.`$table`()?.name
+        is QOM.Delete<*> -> jooqQuery.`$from`()?.name
+        is QOM.Merge<*> -> jooqQuery.`$into`()?.name
+        is Select<*> -> jooqQuery.`$from`().firstOrNull()?.let { (it as? org.jooq.Table<*>)?.name }
+        else -> null
+    }
+
+    fun spanName(jooqQuery: Query?): String {
+        val operation = operationName(jooqQuery)
+        val target = queryTarget(jooqQuery)
+        return if (target == null) operation else "$operation $target"
+    }
+}

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
@@ -3,6 +3,7 @@ package com.razz.eva.tracing
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.api.trace.StatusCode.ERROR
 import io.opentelemetry.context.Context
 import org.jooq.ExecuteContext
 import org.jooq.ExecuteListener
@@ -18,15 +19,18 @@ class QueryTracingListenerProvider(
         private var span: Span? = null
 
         override fun executeStart(context: ExecuteContext) {
-            val rootSpan = Span.fromContextOrNull(Context.current())
-            // We don't want to record queries out of requests/jobs/consumers (f.e. module init or migrations)
-            if (rootSpan != null) {
+            // We don't want to record queries out of requests/jobs/consumers (f.e. module init or migrations),
+            // and isRecording also skips a trace that sampling has already dropped.
+            if (Span.fromContextOrNull(Context.current())?.isRecording == true) {
+                val query = context.query()
                 span = openTelemetry.getTracer("JOOQ")
-                    .spanBuilder("PostgreSQL")
+                    .spanBuilder(QueryNaming.spanName(query))
                     .setAttribute("db.system", "postgresql")
+                    .setAttribute("db.operation.name", QueryNaming.operationName(query))
                     .setAttribute("db.statement", context.sql() ?: "")
                     .setSpanKind(CLIENT)
                     .startSpan()
+                QueryNaming.queryTarget(query)?.let { span?.setAttribute("db.collection.name", it) }
             }
         }
 
@@ -38,6 +42,8 @@ class QueryTracingListenerProvider(
             val ex = ctx.sqlException()
             if (ex != null) {
                 span?.recordException(ex)
+                // Without a status the span metric error rate reads zero for every failed query.
+                span?.setStatus(ERROR)
                 span?.end()
             }
         }

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
@@ -11,11 +11,22 @@ import org.jooq.ExecuteListenerProvider
 
 class QueryTracingListenerProvider(
     private val openTelemetry: OpenTelemetry,
+    /**
+     * Cap on the `db.statement` attribute. A folded multi row insert or a large `IN` list renders to a very
+     * long string, and nothing downstream truncates it: the OpenTelemetry default attribute value length is
+     * unlimited. A statement over the cap is cut, and `db.statement.length` reports what it was.
+     *
+     * Inlined bind values are part of the rendered string, so this also bounds how much of them travels.
+     */
+    private val maxStatementLength: Int = 8 * 1024,
 ) : ExecuteListenerProvider {
 
-    override fun provide(): ExecuteListener = TracingListener(openTelemetry)
+    override fun provide(): ExecuteListener = TracingListener(openTelemetry, maxStatementLength)
 
-    private class TracingListener(private val openTelemetry: OpenTelemetry) : ExecuteListener {
+    private class TracingListener(
+        private val openTelemetry: OpenTelemetry,
+        private val maxStatementLength: Int,
+    ) : ExecuteListener {
         private var span: Span? = null
 
         override fun executeStart(context: ExecuteContext) {
@@ -23,14 +34,18 @@ class QueryTracingListenerProvider(
             // and isRecording also skips a trace that sampling has already dropped.
             if (Span.fromContextOrNull(Context.current())?.isRecording == true) {
                 val query = context.query()
+                val statement = context.sql() ?: ""
                 span = openTelemetry.getTracer("JOOQ")
                     .spanBuilder(QueryNaming.spanName(query))
                     .setAttribute("db.system", "postgresql")
                     .setAttribute("db.operation.name", QueryNaming.operationName(query))
-                    .setAttribute("db.statement", context.sql() ?: "")
+                    .setAttribute("db.statement", statement.take(maxStatementLength))
                     .setSpanKind(CLIENT)
                     .startSpan()
                 QueryNaming.queryTarget(query)?.let { span?.setAttribute("db.collection.name", it) }
+                if (statement.length > maxStatementLength) {
+                    span?.setAttribute("db.statement.length", statement.length.toLong())
+                }
             }
         }
 

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryNamingSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryNamingSpec.kt
@@ -1,0 +1,60 @@
+package com.razz.eva.tracing
+
+import com.razz.eva.tracing.QueryNaming.operationName
+import com.razz.eva.tracing.QueryNaming.queryTarget
+import com.razz.eva.tracing.QueryNaming.spanName
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.jooq.Record
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+
+private val events = object : TableImpl<Record>(DSL.name("model_events")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
+}
+
+class QueryNamingSpec : FunSpec({
+
+    val ctx = DSL.using(POSTGRES)
+    val nullUuid = DSL.inline(null, SQLDataType.UUID)
+
+    test("names a select after the table") {
+        spanName(ctx.selectFrom(events)) shouldBe "SELECT model_events"
+    }
+
+    test("names a dsl delete") {
+        val query = ctx.deleteFrom(events).where(events.ID.isNotNull)
+        operationName(query) shouldBe "DELETE"
+        queryTarget(query) shouldBe "model_events"
+    }
+
+    test("names a dsl insert") {
+        val query = ctx.insertInto(events).columns(events.ID).values(nullUuid)
+        spanName(query) shouldBe "INSERT model_events"
+    }
+
+    test("names a dsl update") {
+        spanName(ctx.update(events).set(events.ID, nullUuid)) shouldBe "UPDATE model_events"
+    }
+
+    test("names a query object insert") {
+        spanName(ctx.insertQuery(events)) shouldBe "INSERT model_events"
+    }
+
+    test("names a query object delete") {
+        spanName(ctx.deleteQuery(events)) shouldBe "DELETE model_events"
+    }
+
+    test("a merge upsert has no target") {
+        val query = ctx.mergeInto(events, events.ID).values(nullUuid)
+        operationName(query) shouldBe "MERGE"
+        queryTarget(query) shouldBe null
+        spanName(query) shouldBe "MERGE"
+    }
+
+    test("an unknown query falls back") {
+        spanName(null) shouldBe "QUERY"
+    }
+})

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
@@ -74,6 +74,24 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
     }
 
     @Test
+    suspend fun `should cap an oversized statement and report its length`() {
+        val listener = QueryTracingListenerProvider(telemetry, maxStatementLength = 16).provide()
+        val long = "delete from model_events where id in (" + "?, ".repeat(50) + ")"
+        val sqlContext = mockk<ExecuteContext> {
+            every { sql() } returns long
+            every { query() } returns jooqQuery
+        }
+        withContext(telemetry.tracerProvider.get("JOOQ").spanBuilder("root").startSpan().asContextElement()) {
+            listener.executeStart(sqlContext)
+            listener.executeEnd(sqlContext)
+        }
+        val span = spanExporter.finishedSpanItems.single()
+        span.attributes.get(stringKey("db.statement")) shouldBe long.take(16)
+        span.attributes.get(io.opentelemetry.api.common.AttributeKey.longKey("db.statement.length")) shouldBe
+            long.length.toLong()
+    }
+
+    @Test
     suspend fun `should end span when query is completed`() {
         // given
         val listener = listenerProvider.provide()

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
@@ -2,6 +2,7 @@ package com.razz.eva.tracing
 
 import io.kotest.core.spec.IsolationMode.InstancePerTest
 import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -18,6 +19,9 @@ import java.sql.SQLException
 import kotlinx.coroutines.withContext
 import org.jooq.ExecuteContext
 
+private val table = org.jooq.impl.DSL.table(org.jooq.impl.DSL.name("model_events"))
+private val jooqQuery = org.jooq.impl.DSL.using(org.jooq.SQLDialect.POSTGRES).deleteQuery(table)
+
 class QueryTracingListenerProviderSpec : AnnotationSpec() {
 
     override fun isolationMode() = InstancePerTest
@@ -33,6 +37,43 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
     val listenerProvider = QueryTracingListenerProvider(telemetry)
 
     @Test
+    suspend fun `should name the span after the operation and the table`() {
+        val listener = listenerProvider.provide()
+        val rootSpan = telemetry.tracerProvider.get("JOOQ").spanBuilder("root").startSpan()
+        val sqlContext = mockk<ExecuteContext> {
+            every { sql() } returns "delete from model_events"
+            every { query() } returns jooqQuery
+        }
+        withContext(rootSpan.asContextElement()) {
+            listener.executeStart(sqlContext)
+            listener.executeEnd(sqlContext)
+        }
+        val span = spanExporter.finishedSpanItems.single()
+        span.name shouldBe "DELETE model_events"
+        span.attributes.get(stringKey("db.operation.name")) shouldBe "DELETE"
+        span.attributes.get(stringKey("db.collection.name")) shouldBe "model_events"
+    }
+
+    @Test
+    suspend fun `should not record a span for a sampled out trace`() {
+        val dropped = OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .setSampler(io.opentelemetry.sdk.trace.samplers.Sampler.alwaysOff())
+                    .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                    .build(),
+            )
+            .build()
+        val listener = listenerProvider.provide()
+        val sqlContext = mockk<ExecuteContext>()
+        withContext(dropped.tracerProvider.get("JOOQ").spanBuilder("root").startSpan().asContextElement()) {
+            listener.executeStart(sqlContext)
+            listener.executeEnd(sqlContext)
+        }
+        spanExporter.finishedSpanItems.shouldBeEmpty()
+    }
+
+    @Test
     suspend fun `should end span when query is completed`() {
         // given
         val listener = listenerProvider.provide()
@@ -41,6 +82,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
             .startSpan()
         val sqlContext = mockk<ExecuteContext> {
             every { sql() } returns "SELECT * FROM table"
+            every { query() } returns jooqQuery
         }
 
         withContext(rootSpan.asContextElement()) {
@@ -69,6 +111,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
         val exception = SQLException("some sql error")
         val sqlContext = mockk<ExecuteContext> {
             every { sql() } returns "SELECT * FROM table"
+            every { query() } returns jooqQuery
             every { sqlException() } returns exception
         }
 
@@ -97,6 +140,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
         val listener = listenerProvider.provide()
         val sqlContext = mockk<ExecuteContext> {
             every { sql() } returns "SELECT * FROM table"
+            every { query() } returns jooqQuery
         }
 
         // when


### PR DESCRIPTION
Three improvements taken from razz-team/eva#304, each one separable from the pool attribution that PR is still arguing about. Nothing here moves span creation into the executors, and no public signature changes.

`QueryNaming` derives a span name from the jOOQ query object. `ExecuteContext.query()` gives the listener the query, so this needs no executor change. A span is named `SELECT model_events` and not the constant `PostgreSQL`, and carries `db.operation.name` and `db.collection.name`. Span metrics that group by name now separate a select on one table from an insert on another, and the table set bounds the cardinality. A dashboard or an alert matching the name `PostgreSQL` needs an update.

The listener sets `ERROR` status on a failed query. It recorded the exception and set no status, so span metric error rates read zero for every failure.

The listener checks `isRecording` and not span presence, so a sampled out trace builds no span.

`db.statement` has a cap, 8 KiB by default, with `db.statement.length` reporting the original length when a statement is cut. A folded multi row insert or a large `IN` list renders very long, inlined bind values are part of that string, and nothing downstream truncates: neither infrastructure repository configures an attribute limit. This follows the shape of `86c7696`, which capped the `uow_events` params column.

Not taken from #304: everything reporting which pool served a query. That is the contested part. The vertx executor still emits no spans, because that needs new code there rather than a listener.

Also not here: every live test engine still builds with a no-op telemetry, so no test in this repository exercises the listener against a live database. That belongs with the first test that asserts a span, and not on its own.
