### PR TITLE
Emit database spans from the vertx executor

### DIFF
--- a/eva-persistence-vertx/build.gradle.kts
+++ b/eva-persistence-vertx/build.gradle.kts
@@ -10,6 +10,7 @@ dependencies {
     api(libs.vertx.pg)
 
     api(project(eva.eva_persistence))
+    api(project(eva.eva_tracing))
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.coroutines)
@@ -20,4 +21,5 @@ dependencies {
     implementation(libs.jooq.postgres)
 
     testImplementation(testFixtures(project(eva.eva_persistence)))
+    testImplementation(libs.opentelemetry.sdk.testing)
 }

--- a/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
+++ b/eva-persistence-vertx/src/main/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutor.kt
@@ -14,6 +14,11 @@ import com.razz.eva.persistence.executor.QueryExecutor.Companion.matchReturning
 import com.razz.eva.persistence.executor.QueryExecutor.Constraint
 import com.razz.eva.persistence.postgres.PgHelpers.PG_CONNECTION_UNAVAILABLE
 import com.razz.eva.persistence.postgres.PgHelpers.PG_UNIQUE_VIOLATION
+import com.razz.eva.tracing.databaseSpan
+import com.razz.eva.tracing.tracingDatabaseQueries
+import com.razz.eva.tracing.use
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.OpenTelemetry.noop
 import io.vertx.core.json.Json
 import io.vertx.kotlin.coroutines.coAwait
 import io.vertx.pgclient.PgConnection
@@ -50,9 +55,16 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.ZoneOffset.UTC
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.EmptyCoroutineContext
 
 class VertxQueryExecutor(
     private val transactionManager: TransactionManager<PgConnection>,
+    /**
+     * Telemetry the spans go to. This executor does not run through jOOQ, so a jOOQ execute listener never
+     * fires for it and it emitted no spans at all before. Pass a real instance to get them.
+     */
+    private val openTelemetry: OpenTelemetry = noop(),
 ) : QueryExecutor {
 
     override suspend fun <R : Record> executeSelect(
@@ -60,9 +72,11 @@ class VertxQueryExecutor(
         jooqQuery: Select<R>,
         table: Table<R>,
     ): List<R> {
-        return transactionManager.withConnection { connection ->
-            val rows = executeQuery(connection, dslContext, jooqQuery, table.fields(), table)
-            rows.toList()
+        return traced(jooqQuery, dslContext) {
+            transactionManager.withConnection { connection ->
+                val rows = executeQuery(connection, dslContext, jooqQuery, table.fields(), table)
+                rows.toList()
+            }
         }
     }
 
@@ -73,16 +87,19 @@ class VertxQueryExecutor(
         returning: Collection<Field<*>>?,
     ): List<ROUT> {
         val matched = returning?.let { matchReturning(jooqQuery, it) }
-        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            val fields = if (matched == null) {
-                jooqQuery.setReturning()
-                table.fields()
-            } else {
-                jooqQuery.setReturning(matched)
-                matched.toTypedArray()
+        // The returning clause is part of the statement, so it is set before the span renders the SQL.
+        val fields = if (matched == null) {
+            jooqQuery.setReturning()
+            table.fields()
+        } else {
+            jooqQuery.setReturning(matched)
+            matched.toTypedArray()
+        }
+        return traced(jooqQuery, dslContext) {
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+                val rows = executeQuery(connection, dslContext, jooqQuery, fields, table)
+                rows.toList()
             }
-            val rows = executeQuery(connection, dslContext, jooqQuery, fields, table)
-            rows.toList()
         }
     }
 
@@ -90,9 +107,11 @@ class VertxQueryExecutor(
         dslContext: DSLContext,
         jooqQuery: DMLQuery<R>,
     ): Int {
-        return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            connection.preparedQuery(dslContext.renderNamedParams(jooqQuery))
-                .execute(bindParams(dslContext, jooqQuery)).map(SqlResult<*>::rowCount).coAwait()
+        return traced(jooqQuery, dslContext) {
+            transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
+                connection.preparedQuery(dslContext.renderNamedParams(jooqQuery))
+                    .execute(bindParams(dslContext, jooqQuery)).map(SqlResult<*>::rowCount).coAwait()
+            }
         }
     }
 
@@ -105,6 +124,21 @@ class VertxQueryExecutor(
     ): RowSet<R> = connection.preparedQuery(dslContext.renderNamedParams(jooqQuery)).mapping { row ->
         convertRowToRecord(dslContext, row, fields, table)
     }.execute(bindParams(dslContext, jooqQuery)).coAwait()
+
+    private suspend fun <T> traced(jooqQuery: Query, dslContext: DSLContext, block: suspend () -> T): T {
+        if (!tracingDatabaseQueries()) {
+            return block()
+        }
+        // Built inside withContext, because withContext runs ensureActive first and a span built outside it
+        // would never end for a call cancelled before it starts. use makes the span current and ends it.
+        return withContext(EmptyCoroutineContext) {
+            openTelemetry.databaseSpan(
+                tracerName = "vertx",
+                jooqQuery = jooqQuery,
+                statement = dslContext.renderNamedParams(jooqQuery),
+            ).use { block() }
+        }
+    }
 
     private fun bindParams(
         dslContext: DSLContext,

--- a/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTracingSpec.kt
+++ b/eva-persistence-vertx/src/test/kotlin/com/razz/eva/persistence/vertx/executor/VertxQueryExecutorTracingSpec.kt
@@ -1,0 +1,127 @@
+package com.razz.eva.persistence.vertx.executor
+
+import com.razz.eva.persistence.vertx.PgPoolConnectionProvider
+import com.razz.eva.persistence.vertx.VertxConnectionElement
+import com.razz.eva.persistence.vertx.VertxTransactionManager
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.api.trace.StatusCode
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import io.vertx.core.Future.succeededFuture
+import io.vertx.pgclient.PgConnection
+import io.vertx.sqlclient.PreparedQuery
+import io.vertx.sqlclient.Row
+import io.vertx.sqlclient.RowSet
+import io.vertx.sqlclient.impl.ListTuple
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.jooq.Record
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+import java.util.function.Function
+
+private val orders = object : TableImpl<Record>(DSL.name("payment_order")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
+}
+
+/**
+ * The vertx executor does not run through jOOQ, so the jOOQ execute listener never fires for it. Before this
+ * it emitted no spans, which made a service's traces depend on the executor it started with.
+ */
+class VertxQueryExecutorTracingSpec : ShouldSpec({
+
+    val dslContext = DSL.using(POSTGRES)
+    val spanExporter = InMemorySpanExporter.create()
+    val telemetry = OpenTelemetrySdk.builder()
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build(),
+        )
+        .build()
+
+    val connectionProvider = mockk<PgPoolConnectionProvider>(relaxed = true)
+    val transactionManager = spyk(VertxTransactionManager(connectionProvider, connectionProvider))
+    val executor = VertxQueryExecutor(transactionManager, telemetry)
+
+    val preparedQueryMock = mockk<PreparedQuery<RowSet<Row>>> {
+        every { mapping(any<Function<Row, Any>>()) } answers {
+            mockk {
+                every { execute(any<ListTuple>()) } returns succeededFuture(
+                    mockk {
+                        every { iterator() } answers { mockk { every { hasNext() } returns false } }
+                        every { size() } returns 0
+                    },
+                )
+            }
+        }
+    }
+    val connection = mockk<PgConnection>(relaxed = true) {
+        every { preparedQuery(any()) } answers { preparedQueryMock }
+    }
+    coEvery { connectionProvider.acquire() } coAnswers { connection }
+
+    fun root() = telemetry.tracerProvider.get("test").spanBuilder("root").startSpan()
+
+    suspend fun select() {
+        withContext(Dispatchers.IO + VertxConnectionElement(connection)) {
+            executor.executeSelect(dslContext, dslContext.selectFrom(orders), orders)
+        }
+    }
+
+    should("emit a span named after the operation and the table") {
+        spanExporter.reset()
+        val root = root()
+        withContext(root.asContextElement()) { select() }
+        root.end()
+
+        val span = spanExporter.finishedSpanItems.single { it.name != "root" }
+        span.name shouldBe "SELECT payment_order"
+        span.kind shouldBe CLIENT
+        span.attributes.get(stringKey("db.system")) shouldBe "postgresql"
+        span.attributes.get(stringKey("db.operation.name")) shouldBe "SELECT"
+        span.attributes.get(stringKey("db.collection.name")) shouldBe "payment_order"
+        span.parentSpanId shouldBe root.spanContext.spanId
+    }
+
+    should("report the statement the driver receives") {
+        spanExporter.reset()
+        val root = root()
+        withContext(root.asContextElement()) { select() }
+        root.end()
+
+        val span = spanExporter.finishedSpanItems.single { it.name != "root" }
+        span.attributes.get(stringKey("db.statement")) shouldBe
+            """select "payment_order"."id" from "payment_order""""
+    }
+
+    should("leave the caller span free of database attributes") {
+        spanExporter.reset()
+        val root = root()
+        withContext(root.asContextElement()) { select() }
+        root.end()
+
+        val parent = spanExporter.finishedSpanItems.single { it.name == "root" }
+        parent.attributes.get(stringKey("db.system")) shouldBe null
+        parent.status.statusCode shouldBe StatusCode.UNSET
+    }
+
+    should("emit nothing outside a request") {
+        spanExporter.reset()
+        select()
+        spanExporter.finishedSpanItems.shouldBeEmpty()
+    }
+})

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpan.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpan.kt
@@ -1,0 +1,43 @@
+package com.razz.eva.tracing
+
+import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.context.Context
+import org.jooq.Query
+
+/** Default cap on the `db.statement` attribute. */
+const val MAX_STATEMENT_LENGTH: Int = 8 * 1024
+
+/**
+ * Whether anything is being recorded. A caller checks this before doing the work a span needs, which keeps
+ * queries outside a request, a job or a consumer untraced, module initialisation and migrations among them.
+ * A sampled out trace is not recording either.
+ */
+fun tracingDatabaseQueries(): Boolean = Span.fromContextOrNull(Context.current())?.isRecording == true
+
+/**
+ * A span for one database query, named and attributed by the semantic conventions for database clients.
+ *
+ * Both the jOOQ execute listener and the vertx executor build their spans here, so the two paths cannot
+ * drift on a name or an attribute.
+ */
+fun OpenTelemetry.databaseSpan(
+    tracerName: String,
+    jooqQuery: Query?,
+    statement: String,
+    maxStatementLength: Int = MAX_STATEMENT_LENGTH,
+): Span {
+    val span = getTracer(tracerName)
+        .spanBuilder(QueryNaming.spanName(jooqQuery))
+        .setAttribute("db.system", "postgresql")
+        .setAttribute("db.operation.name", QueryNaming.operationName(jooqQuery))
+        .setAttribute("db.statement", statement.take(maxStatementLength))
+        .setSpanKind(CLIENT)
+        .startSpan()
+    QueryNaming.queryTarget(jooqQuery)?.let { span.setAttribute("db.collection.name", it) }
+    if (statement.length > maxStatementLength) {
+        span.setAttribute("db.statement.length", statement.length.toLong())
+    }
+    return span
+}

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
@@ -2,9 +2,7 @@ package com.razz.eva.tracing
 
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.SpanKind.CLIENT
 import io.opentelemetry.api.trace.StatusCode.ERROR
-import io.opentelemetry.context.Context
 import org.jooq.ExecuteContext
 import org.jooq.ExecuteListener
 import org.jooq.ExecuteListenerProvider
@@ -18,7 +16,7 @@ class QueryTracingListenerProvider(
      *
      * Inlined bind values are part of the rendered string, so this also bounds how much of them travels.
      */
-    private val maxStatementLength: Int = 8 * 1024,
+    private val maxStatementLength: Int = MAX_STATEMENT_LENGTH,
 ) : ExecuteListenerProvider {
 
     override fun provide(): ExecuteListener = TracingListener(openTelemetry, maxStatementLength)
@@ -30,22 +28,13 @@ class QueryTracingListenerProvider(
         private var span: Span? = null
 
         override fun executeStart(context: ExecuteContext) {
-            // We don't want to record queries out of requests/jobs/consumers (f.e. module init or migrations),
-            // and isRecording also skips a trace that sampling has already dropped.
-            if (Span.fromContextOrNull(Context.current())?.isRecording == true) {
-                val query = context.query()
-                val statement = context.sql() ?: ""
-                span = openTelemetry.getTracer("JOOQ")
-                    .spanBuilder(QueryNaming.spanName(query))
-                    .setAttribute("db.system", "postgresql")
-                    .setAttribute("db.operation.name", QueryNaming.operationName(query))
-                    .setAttribute("db.statement", statement.take(maxStatementLength))
-                    .setSpanKind(CLIENT)
-                    .startSpan()
-                QueryNaming.queryTarget(query)?.let { span?.setAttribute("db.collection.name", it) }
-                if (statement.length > maxStatementLength) {
-                    span?.setAttribute("db.statement.length", statement.length.toLong())
-                }
+            if (tracingDatabaseQueries()) {
+                span = openTelemetry.databaseSpan(
+                    tracerName = "JOOQ",
+                    jooqQuery = context.query(),
+                    statement = context.sql() ?: "",
+                    maxStatementLength = maxStatementLength,
+                )
             }
         }
 


### PR DESCRIPTION
The vertx executor emitted no database spans. It uses jOOQ only to render SQL and to extract bind values, then executes through `connection.preparedQuery`, so jOOQ's execute lifecycle never runs and the execute listener never fires for it. A service traced its queries or did not, depending on the executor it started with.

`VertxQueryExecutor` now builds a span per query. It takes an `OpenTelemetry`, which defaults to a no-op, so a caller passes a real instance to get spans.

The span carries what the listener already reports: the `{operation} {table}` name, `db.system`, `db.operation.name`, `db.collection.name`, and `db.statement` under the same 8 KiB cap. On this path the statement holds `$1` placeholders, because that is what the driver receives.

Both paths build the span in one place, `OpenTelemetry.databaseSpan` in eva-tracing, so a name or an attribute cannot drift between them. The listener now calls it. `tracingDatabaseQueries()` holds the `isRecording` check that both paths need.

The span is built inside `withContext`, because `withContext` runs `ensureActive` first and a span built outside it would never end for a call cancelled before it starts. `Span?.use` makes it current and ends it, so a failed query gets `ERROR` status.

`executeStore` sets the returning clause before the span renders the statement, so `db.statement` includes it.

This reports nothing about which pool served a query. That is razz-team/eva#304 and it stays open.

`VertxQueryExecutorTracingSpec` covers the name and the attributes, the statement the driver receives, that the caller's span stays free of database attributes and unset status, and that nothing is emitted outside a request.
