### PR TITLE
Name jdbc query spans after the operation and the table

### DIFF
--- a/eva-persistence-jdbc/build.gradle.kts
+++ b/eva-persistence-jdbc/build.gradle.kts
@@ -1,6 +1,14 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("eva-kotlin")
     id("eva-publish")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    friendPaths.from(
+        rootProject.project("eva-tracing").layout.buildDirectory.dir("classes/kotlin/main"),
+    )
 }
 
 dependencies {

--- a/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
+++ b/eva-persistence-jdbc/src/main/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutor.kt
@@ -46,7 +46,7 @@ class JdbcQueryExecutor(
         table: Table<R>,
     ): List<R> {
         return transactionManager.withConnection { connection ->
-            dslContext.using(connection).preparedQuery(jooqQuery).coerce(table).fetch()
+            dslContext.preparedQuery(connection, jooqQuery).coerce(table).fetch()
         }
     }
 
@@ -59,13 +59,13 @@ class JdbcQueryExecutor(
         return if (returning == null) {
             jooqQuery.setReturning()
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                dslContext.using(connection).preparedQuery(jooqQuery).coerce(table).fetch()
+                dslContext.preparedQuery(connection, jooqQuery).coerce(table).fetch()
             }
         } else {
             val fields = matchReturning(jooqQuery, returning)
             jooqQuery.setReturning(fields)
             transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-                dslContext.using(connection).preparedQuery(jooqQuery).coerce(fields).fetch().map { it.into(table) }
+                dslContext.preparedQuery(connection, jooqQuery).coerce(fields).fetch().map { it.into(table) }
             }
         }
     }
@@ -75,7 +75,7 @@ class JdbcQueryExecutor(
         jooqQuery: DMLQuery<R>,
     ): Int {
         return transactionManager.inTransaction(REQUIRE_EXISTING) { connection ->
-            dslContext.using(connection).run {
+            dslContext.using(connection, jooqQuery).run {
                 execute(
                     render(jooqQuery),
                     *extractParams(jooqQuery)
@@ -88,14 +88,17 @@ class JdbcQueryExecutor(
     }
 
     private fun DSLContext.preparedQuery(
+        connection: Connection,
         jooqQuery: Query,
-    ): ResultQuery<Record> = resultQuery(
-        render(jooqQuery),
-        *extractParams(jooqQuery)
-            .values
-            .filterNot(Param<*>::isInline)
-            .toTypedArray(),
-    )
+    ): ResultQuery<Record> = using(connection, jooqQuery).run {
+        resultQuery(
+            render(jooqQuery),
+            *extractParams(jooqQuery)
+                .values
+                .filterNot(Param<*>::isInline)
+                .toTypedArray(),
+        )
+    }
 
     override fun extractConstraintName(ex: Exception): Constraint? {
         val dataAccessException = ex as? DataAccessException ?: return null
@@ -152,11 +155,12 @@ class JdbcQueryExecutor(
     private fun DataAccessException.connectionUnavailable(): Boolean =
         sqlStateClass() == C08_CONNECTION_EXCEPTION || sqlState() in PG_CONNECTION_UNAVAILABLE
 
-    private fun DSLContext.using(connection: Connection): DSLContext {
+    private fun DSLContext.using(connection: Connection, jooqQuery: Query): DSLContext {
         val configWithConnection = configuration()
             .derive(connection)
             .derive(settings())
-            .derive(QueryTracingListenerProvider(openTelemetry))
+            // the statement runs as rendered plain sql, so the listener has no query object to name a span from
+            .derive(QueryTracingListenerProvider(openTelemetry, jooqQuery))
 
         return DSL.using(configWithConnection)
     }

--- a/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorTracingSpec.kt
+++ b/eva-persistence-jdbc/src/test/kotlin/com/razz/eva/persistence/jdbc/executor/JdbcQueryExecutorTracingSpec.kt
@@ -1,0 +1,65 @@
+package com.razz.eva.persistence.jdbc.executor
+
+import com.razz.eva.persistence.jdbc.JdbcConnectionProvider
+import com.razz.eva.persistence.jdbc.JdbcTransactionManager
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import io.opentelemetry.api.common.AttributeKey.stringKey
+import io.opentelemetry.api.trace.SpanKind.CLIENT
+import io.opentelemetry.extension.kotlin.asContextElement
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import kotlinx.coroutines.withContext
+import org.jooq.Record
+import org.jooq.SQLDialect.POSTGRES
+import org.jooq.impl.DSL
+import org.jooq.impl.SQLDataType
+import org.jooq.impl.TableImpl
+import org.jooq.tools.jdbc.MockConnection
+import org.jooq.tools.jdbc.MockResult
+
+private val orders = object : TableImpl<Record>(DSL.name("payment_order")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
+}
+
+/**
+ * This executor renders a query and then runs plain SQL, so the jOOQ execute listener sees a plain SQL query
+ * and no query object it can name a span from. Without the query the executor started with, every span reads
+ * `QUERY` and carries no table.
+ */
+class JdbcQueryExecutorTracingSpec : ShouldSpec({
+
+    val dslContext = DSL.using(POSTGRES)
+    val spanExporter = InMemorySpanExporter.create()
+    val telemetry = OpenTelemetrySdk.builder()
+        .setTracerProvider(
+            SdkTracerProvider.builder()
+                .addSpanProcessor(SimpleSpanProcessor.create(spanExporter))
+                .build(),
+        )
+        .build()
+
+    val connection = MockConnection { arrayOf(MockResult(0, dslContext.newResult(orders))) }
+    val connectionProvider = mockk<JdbcConnectionProvider>(relaxed = true) {
+        coEvery { acquire() } returns connection
+    }
+    val transactionManager = JdbcTransactionManager(connectionProvider, connectionProvider)
+    val executor = JdbcQueryExecutor(transactionManager, telemetry)
+
+    should("name the span after the operation and the table of the query it was given") {
+        val caller = telemetry.tracerProvider.get("test").spanBuilder("caller").startSpan()
+        withContext(caller.asContextElement()) {
+            executor.executeSelect(dslContext, dslContext.selectFrom(orders), orders)
+        }
+        val span = spanExporter.finishedSpanItems.single { it.name != "caller" }
+        span.name shouldBe "SELECT payment_order"
+        span.attributes[stringKey("db.operation.name")] shouldBe "SELECT"
+        span.attributes[stringKey("db.collection.name")] shouldBe "payment_order"
+        span.attributes[stringKey("db.system")] shouldBe "postgresql"
+        span.kind shouldBe CLIENT
+    }
+})

--- a/eva-persistence-vertx/build.gradle.kts
+++ b/eva-persistence-vertx/build.gradle.kts
@@ -1,6 +1,14 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     id("eva-kotlin")
     id("eva-publish")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    friendPaths.from(
+        rootProject.project("eva-tracing").layout.buildDirectory.dir("classes/kotlin/main"),
+    )
 }
 
 dependencies {

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpan.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/DatabaseSpan.kt
@@ -7,14 +7,14 @@ import io.opentelemetry.context.Context
 import org.jooq.Query
 
 /** Default cap on the `db.statement` attribute. */
-const val MAX_STATEMENT_LENGTH: Int = 8 * 1024
+internal const val MAX_STATEMENT_LENGTH: Int = 8 * 1024
 
 /**
  * Whether anything is being recorded. A caller checks this before doing the work a span needs, which keeps
  * queries outside a request, a job or a consumer untraced, module initialisation and migrations among them.
  * A sampled out trace is not recording either.
  */
-fun tracingDatabaseQueries(): Boolean = Span.fromContextOrNull(Context.current())?.isRecording == true
+internal fun tracingDatabaseQueries(): Boolean = Span.fromContextOrNull(Context.current())?.isRecording == true
 
 /**
  * A span for one database query, named and attributed by the semantic conventions for database clients.
@@ -22,7 +22,7 @@ fun tracingDatabaseQueries(): Boolean = Span.fromContextOrNull(Context.current()
  * Both the jOOQ execute listener and the vertx executor build their spans here, so the two paths cannot
  * drift on a name or an attribute.
  */
-fun OpenTelemetry.databaseSpan(
+internal fun OpenTelemetry.databaseSpan(
     tracerName: String,
     jooqQuery: Query?,
     statement: String,

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
@@ -14,7 +14,7 @@ import org.jooq.impl.QOM
  * The semantic conventions ask for `{db.operation.name} {target}`. A constant name puts every database call
  * in one span metric bucket, and the table set bounds the cardinality of this one.
  */
-object QueryNaming {
+internal object QueryNaming {
 
     fun operationName(jooqQuery: Query?): String = when (jooqQuery) {
         is Select<*> -> "SELECT"

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
@@ -8,7 +8,7 @@ import org.jooq.ExecuteListener
 import org.jooq.ExecuteListenerProvider
 import org.jooq.Query
 
-class QueryTracingListenerProvider(
+internal class QueryTracingListenerProvider(
     private val openTelemetry: OpenTelemetry,
     /**
      * The typed query the statement came from. An executor that renders a query to text and then runs plain

--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryTracingListenerProvider.kt
@@ -6,9 +6,19 @@ import io.opentelemetry.api.trace.StatusCode.ERROR
 import org.jooq.ExecuteContext
 import org.jooq.ExecuteListener
 import org.jooq.ExecuteListenerProvider
+import org.jooq.Query
 
 class QueryTracingListenerProvider(
     private val openTelemetry: OpenTelemetry,
+    /**
+     * The typed query the statement came from. An executor that renders a query to text and then runs plain
+     * SQL leaves jOOQ with nothing to name a span from: [ExecuteContext.query] reports the plain SQL query,
+     * which matches no QOM type, so the span reads `QUERY` and carries no table. Such an executor builds one
+     * provider per statement and passes the query it started with here.
+     *
+     * Null leaves the naming to [ExecuteContext.query], which is what a jOOQ built statement needs.
+     */
+    private val sourceQuery: Query?,
     /**
      * Cap on the `db.statement` attribute. A folded multi row insert or a large `IN` list renders to a very
      * long string, and nothing downstream truncates it: the OpenTelemetry default attribute value length is
@@ -19,10 +29,11 @@ class QueryTracingListenerProvider(
     private val maxStatementLength: Int = MAX_STATEMENT_LENGTH,
 ) : ExecuteListenerProvider {
 
-    override fun provide(): ExecuteListener = TracingListener(openTelemetry, maxStatementLength)
+    override fun provide(): ExecuteListener = TracingListener(openTelemetry, sourceQuery, maxStatementLength)
 
     private class TracingListener(
         private val openTelemetry: OpenTelemetry,
+        private val sourceQuery: Query?,
         private val maxStatementLength: Int,
     ) : ExecuteListener {
         private var span: Span? = null
@@ -31,7 +42,7 @@ class QueryTracingListenerProvider(
             if (tracingDatabaseQueries()) {
                 span = openTelemetry.databaseSpan(
                     tracerName = "JOOQ",
-                    jooqQuery = context.query(),
+                    jooqQuery = sourceQuery ?: context.query(),
                     statement = context.sql() ?: "",
                     maxStatementLength = maxStatementLength,
                 )

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
@@ -21,6 +21,8 @@ import org.jooq.ExecuteContext
 
 private val table = org.jooq.impl.DSL.table(org.jooq.impl.DSL.name("model_events"))
 private val jooqQuery = org.jooq.impl.DSL.using(org.jooq.SQLDialect.POSTGRES).deleteQuery(table)
+private val plainSql = org.jooq.impl.DSL.using(org.jooq.SQLDialect.POSTGRES)
+    .resultQuery("delete from model_events")
 
 class QueryTracingListenerProviderSpec : AnnotationSpec() {
 
@@ -34,7 +36,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
                 .build(),
         )
         .build()
-    val listenerProvider = QueryTracingListenerProvider(telemetry)
+    val listenerProvider = QueryTracingListenerProvider(telemetry, sourceQuery = null)
 
     @Test
     suspend fun `should name the span after the operation and the table`() {
@@ -52,6 +54,39 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
         span.name shouldBe "DELETE model_events"
         span.attributes.get(stringKey("db.operation.name")) shouldBe "DELETE"
         span.attributes.get(stringKey("db.collection.name")) shouldBe "model_events"
+    }
+
+    @Test
+    suspend fun `should name the span after the query the rendered sql came from`() {
+        val listener = QueryTracingListenerProvider(telemetry, sourceQuery = jooqQuery).provide()
+        val sqlContext = mockk<ExecuteContext> {
+            every { sql() } returns "delete from model_events"
+            every { query() } returns plainSql
+        }
+        withContext(telemetry.tracerProvider.get("JOOQ").spanBuilder("root").startSpan().asContextElement()) {
+            listener.executeStart(sqlContext)
+            listener.executeEnd(sqlContext)
+        }
+        val span = spanExporter.finishedSpanItems.single()
+        span.name shouldBe "DELETE model_events"
+        span.attributes.get(stringKey("db.operation.name")) shouldBe "DELETE"
+        span.attributes.get(stringKey("db.collection.name")) shouldBe "model_events"
+    }
+
+    @Test
+    suspend fun `should name a plain sql statement after the operation alone`() {
+        val listener = listenerProvider.provide()
+        val sqlContext = mockk<ExecuteContext> {
+            every { sql() } returns "delete from model_events"
+            every { query() } returns plainSql
+        }
+        withContext(telemetry.tracerProvider.get("JOOQ").spanBuilder("root").startSpan().asContextElement()) {
+            listener.executeStart(sqlContext)
+            listener.executeEnd(sqlContext)
+        }
+        val span = spanExporter.finishedSpanItems.single()
+        span.name shouldBe "QUERY"
+        span.attributes.get(stringKey("db.collection.name")) shouldBe null
     }
 
     @Test
@@ -75,7 +110,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
 
     @Test
     suspend fun `should cap an oversized statement and report its length`() {
-        val listener = QueryTracingListenerProvider(telemetry, maxStatementLength = 16).provide()
+        val listener = QueryTracingListenerProvider(telemetry, sourceQuery = null, maxStatementLength = 16).provide()
         val long = "delete from model_events where id in (" + "?, ".repeat(50) + ")"
         val sqlContext = mockk<ExecuteContext> {
             every { sql() } returns long

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryTracingListenerProviderSpec.kt
@@ -36,7 +36,7 @@ class QueryTracingListenerProviderSpec : AnnotationSpec() {
                 .build(),
         )
         .build()
-    val listenerProvider = QueryTracingListenerProvider(telemetry, sourceQuery = null)
+    private val listenerProvider = QueryTracingListenerProvider(telemetry, sourceQuery = null)
 
     @Test
     suspend fun `should name the span after the operation and the table`() {


### PR DESCRIPTION
The jdbc executor renders a query to text and then runs plain SQL. jOOQ reports that plain SQL query in `ExecuteContext.query()`, and it matches no QOM type, so `QueryNaming` fell through to its last branch. The naming from #309 only ever worked for the vertx executor, which hands the typed query to its span builder directly.

One span, for `select ... from payment_order` on the jdbc executor:

|                       | before                | after                  |
| --------------------- | --------------------- | ---------------------- |
| span name             | `QUERY`               | `SELECT payment_order` |
| `db.operation.name`   | `QUERY`               | `SELECT`               |
| `db.collection.name`  | absent                | `payment_order`        |
| `db.system`           | `postgresql`          | `postgresql`           |
| `db.statement`        | rendered sql, capped  | rendered sql, capped   |

The signatures that move:

|                                      | before                                | after                                              |
| ------------------------------------ | ------------------------------------- | -------------------------------------------------- |
| `QueryTracingListenerProvider`       | `(openTelemetry, maxStatementLength)` | `(openTelemetry, sourceQuery, maxStatementLength)` |
| `DSLContext.using` (private)         | `(connection)`                        | `(connection, jooqQuery)`                          |
| `DSLContext.preparedQuery` (private) | `(jooqQuery)`                         | `(connection, jooqQuery)`                          |

`sourceQuery` has no default, so each call site states what it names spans from. Null keeps the earlier behaviour and names the span from `ExecuteContext.query()`, which is what a statement jOOQ built itself needs. The two private signatures make one context serve one statement, so the query behind a statement cannot go missing at a later edit.

What eva-tracing publishes:

|                          | before   | after      |
| ------------------------ | -------- | ---------- |
| `QueryTracingListenerProvider` | public   | internal   |
| `QueryNaming`            | public   | internal   |
| `databaseSpan`           | public   | internal   |
| `tracingDatabaseQueries` | public   | internal   |
| `MAX_STATEMENT_LENGTH`   | public   | internal   |

These five serve the two executors and nothing else, so the executor modules reach them through `friendPaths` in the same way `eva-repository` reaches `eva-domain`. The propagation and span helpers stay public.

The vertx executor is untouched, and no attribute other than the three above changes.

`JdbcQueryExecutorTracingSpec` runs a select through the executor over a jOOQ mock connection and asserts the span name. I checked that it fails when the executor stops passing the query. Two cases in `QueryTracingListenerProviderSpec` cover a plain SQL query, one with a source query and one without, which is the pair of tests that was missing when #309 shipped.
