### PR TITLE
Name a joined select after its leftmost table

### DIFF
--- a/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
+++ b/eva-tracing/src/main/kotlin/com/razz/eva/tracing/QueryNaming.kt
@@ -5,6 +5,7 @@ import org.jooq.Insert
 import org.jooq.Merge
 import org.jooq.Query
 import org.jooq.Select
+import org.jooq.Table
 import org.jooq.Update
 import org.jooq.impl.QOM
 
@@ -30,14 +31,25 @@ internal object QueryNaming {
      * a [QOM.Delete] and not a `DeleteQuery`, so matching only the latter would name nothing at all.
      *
      * A merge upsert returns null. `org.jooq.impl.MergeUpsert` implements [Merge] and not [QOM.Merge].
+     *
+     * A select over a join reports the leftmost table of the from clause.
      */
     fun queryTarget(jooqQuery: Query?): String? = when (jooqQuery) {
         is QOM.Insert<*> -> jooqQuery.`$into`()?.name
         is QOM.Update<*> -> jooqQuery.`$table`()?.name
         is QOM.Delete<*> -> jooqQuery.`$from`()?.name
         is QOM.Merge<*> -> jooqQuery.`$into`()?.name
-        is Select<*> -> jooqQuery.`$from`().firstOrNull()?.let { (it as? org.jooq.Table<*>)?.name }
+        is Select<*> -> primaryTable(jooqQuery.`$from`().firstOrNull())
         else -> null
+    }
+
+    // jOOQ models a join as a table of its own, and that table is named `join`, so a select over one reported
+    // that word as the collection. A repository selects from its own table and joins the rest, which makes the
+    // leftmost table the one the statement is about.
+    private tailrec fun primaryTable(table: Table<*>?): String? = when (table) {
+        null -> null
+        is QOM.JoinTable<*, *> -> primaryTable(table.`$table1`())
+        else -> table.name
     }
 
     fun spanName(jooqQuery: Query?): String {

--- a/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryNamingSpec.kt
+++ b/eva-tracing/src/test/kotlin/com/razz/eva/tracing/QueryNamingSpec.kt
@@ -15,6 +15,14 @@ private val events = object : TableImpl<Record>(DSL.name("model_events")) {
     val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
 }
 
+private val principals = object : TableImpl<Record>(DSL.name("principal")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
+}
+
+private val departments = object : TableImpl<Record>(DSL.name("department")) {
+    val ID = createField(DSL.name("id"), SQLDataType.UUID)!!
+}
+
 class QueryNamingSpec : FunSpec({
 
     val ctx = DSL.using(POSTGRES)
@@ -52,6 +60,20 @@ class QueryNamingSpec : FunSpec({
         operationName(query) shouldBe "MERGE"
         queryTarget(query) shouldBe null
         spanName(query) shouldBe "MERGE"
+    }
+
+    test("names a select over a join after its leftmost table") {
+        val query = ctx.select(events.ID).from(events.join(principals).on(events.ID.eq(principals.ID)))
+        operationName(query) shouldBe "SELECT"
+        queryTarget(query) shouldBe "model_events"
+    }
+
+    test("names a select over nested joins after its leftmost table") {
+        val query = ctx.select(events.ID).from(
+            events.join(principals).on(events.ID.eq(principals.ID))
+                .leftJoin(departments).on(events.ID.eq(departments.ID)),
+        )
+        spanName(query) shouldBe "SELECT model_events"
     }
 
     test("an unknown query falls back") {


### PR DESCRIPTION
A select over a join reported `join` as its table. jOOQ models a join as a table of its own, and `Table.getName()` on it returns the word `join`, so `queryTarget` took that as the collection.

Seen in prod, on a `bankfeed_transaction` select that joins two user tables, an account, and a match table:

|                       | before        | after                        |
| --------------------- | ------------- | ---------------------------- |
| span name             | `SELECT join` | `SELECT bankfeed_transaction` |
| `db.collection.name`  | `join`        | `bankfeed_transaction`       |

`queryTarget` now walks the left side of a join until it reaches a plain table, so a nested join resolves to the same leftmost table. A repository selects from its own table and joins the rest, which makes that table the one a statement is about.

Only a joined select changes. A select from one table, an insert, an update, a delete, and a merge all report what they reported before.

`QueryNamingSpec` gains a join case and a nested join case. I checked both fail when the walk follows the right side of the join instead of the left.
