### PR TITLE
Forbid idModelParam from within a uow

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/ModelParam.kt
@@ -90,5 +90,15 @@ class ModelParam<MID : ModelId<out Comparable<*>>, M : Model<MID, *>> private co
         ): ModelParam<MID, M> {
             return ModelParam(modelId, modelQueries)
         }
+
+        @Deprecated(
+            message = "idModelParam re-reads the model inside the uow and would not see the enclosing uow's " +
+                "uncommitted changes; pass the in-memory model with constantModelParam instead",
+            level = DeprecationLevel.ERROR,
+        )
+        fun <MID : ModelId<out Comparable<*>>, M : Model<MID, *>> InstantiationContext.Internal.idModelParam(
+            modelId: MID,
+            modelQueries: suspend (MID) -> M,
+        ): ModelParam<MID, M> = error("idModelParam is not callable from within a uow")
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/ModelParamSpec.kt
@@ -3,6 +3,7 @@ package com.razz.eva.uow
 import com.razz.eva.domain.TestModel
 import com.razz.eva.domain.TestModelId
 import com.razz.eva.domain.TestModelId.Companion.randomTestModelId
+import com.razz.eva.uow.ModelParam.Factory.idModelParam
 import com.razz.eva.uow.ModelParam.Factory.modelParam
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
@@ -89,6 +90,21 @@ class ModelParamSpec : FunSpec({
         val modelParam = InstantiationContext(0).modelParam(heldModel) { error("not used") }
         Thread.sleep(STALENESS_SLEEP_MILLIS)
         modelParam.model().param1 shouldBe heldModel.param1
+    }
+
+    test("Id model param queries its model on first access and caches it") {
+        val model = TestModel.existingCreatedTestModel(param1 = "lel", param2 = 1337)
+        var queryCount = 0
+        val modelParam = idModelParam(model.id()) { id ->
+            queryCount++
+            id shouldBe model.id()
+            model
+        }
+        modelParam.id() shouldBe model.id()
+        queryCount shouldBe 0
+        modelParam.model().param1 shouldBe "lel"
+        modelParam.model().param1 shouldBe "lel"
+        queryCount shouldBe 1
     }
 
     test("Deserialized model param returns its id but refuses to load a model") {


### PR DESCRIPTION
Adds an `InstantiationContext.Internal`-receiver overload marked `DeprecationLevel.ERROR`.                                                                                         
Overload resolution prefers a matching extension receiver, so a call inside such a lambda                                                                                          
binds to it and fails to compile with the explanation; everywhere else no `Internal`                                                                                               
receiver is in scope, the receiver-less function binds as before, and nothing changes.                                                                                             
A single existing `import ModelParam.Factory.idModelParam` pulls in both overloads, so                                                                                             
no call site changes.