### PR TITLE
Add observer seam and bound saga restarts

### DIFF
--- a/eva-saga/build.gradle.kts
+++ b/eva-saga/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 
 dependencies {
     implementation(project(eva.eva_domain))
-    implementation(libs.kotlin.coroutines)
     implementation(libs.kotlin.logging)
     api(project(eva.eva_tracing))
 

--- a/eva-saga/build.gradle.kts
+++ b/eva-saga/build.gradle.kts
@@ -5,5 +5,9 @@ plugins {
 
 dependencies {
     implementation(project(eva.eva_domain))
+    implementation(libs.kotlin.coroutines)
+    implementation(libs.kotlin.logging)
     api(project(eva.eva_tracing))
+
+    testImplementation(libs.opentelemetry.sdk.testing)
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -117,7 +117,6 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                     trail = trail + nextStep::class
                     step = nextStep
                 }
-
                 is Terminal<*> -> {
                     Span.current().setAttribute(SAGA_TERMINAL, current::class.simpleName ?: UNKNOWN_TERMINAL)
                     emit(sagaRun.sagaName, Notification.TERMINATED) {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -275,3 +275,10 @@ private sealed interface StepOutcome<out STEP> {
     class Resolved<STEP>(val step: STEP) : StepOutcome<STEP>
     class Threw(val ex: Exception) : StepOutcome<Nothing>
 }
+
+private sealed interface SagaOutcome<out TERMINAL> {
+
+    class Ended<TERMINAL>(val terminal: TERMINAL) : SagaOutcome<TERMINAL>
+
+    class Restart(val backoff: Duration) : SagaOutcome<Nothing>
+}

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -103,7 +103,6 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                     advance(restarted, null, setOf(), System.nanoTime())
                 }
             }
-
             is StepOutcome.Resolved -> {
                 val nextStep = stepOutcome.step
                 val nextTrail = if (step == null) setOf(nextStep::class) else trail + nextStep::class

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -84,7 +84,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         val starting = currentStep == null
         val stepOutcome = if (starting) {
             recordAttempt(sagaRun)
-            initialise(sagaRun)
+            resolveFirst(sagaRun)
         } else {
             resolveNext(sagaRun, currentStep, trail)
         }
@@ -127,7 +127,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         }
     }
 
-    private suspend fun initialise(sagaRun: SagaRun<PRINCIPAL, PARAMS>): StepOutcome<Step<SELF>> =
+    private suspend fun resolveFirst(sagaRun: SagaRun<PRINCIPAL, PARAMS>): StepOutcome<Step<SELF>> =
         try {
             StepOutcome.Resolved(
                 startSagaInitSpan(sagaRun.sagaName).use {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -91,18 +91,16 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             resolveNext(sagaRun, currentStep, trail)
         }
         return when (stepOutcome) {
-            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex)) {
+            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex, startedAt)) {
                 is SagaOutcome.Ended -> recordTerminal(sagaOutcome.terminal)
                 is SagaOutcome.Restart -> {
-                    val backoff = restartAfter(sagaRun.attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
                     val restartedSagaRun = sagaRun.copy(
                         id = SagaRunId.random(),
                         parentId = sagaRun.id,
                         attempt = sagaRun.attempt + 1,
-                        sagaName = sagaName,
                     )
                     recordRestart(restartedSagaRun, sagaRun.id)
-                    delay(backoff.toMillis().milliseconds)
+                    delay(sagaOutcome.backoff.toMillis().milliseconds)
                     advance(restartedSagaRun, null, setOf(), System.nanoTime())
                 }
             }
@@ -171,16 +169,25 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         sagaRun: SagaRun<PRINCIPAL, PARAMS>,
         step: IS?,
         ex: Exception,
+        startedAt: Long,
     ): SagaOutcome<TS> {
         Span.current().recordException(ex)
         val mapped = try {
             onException(ex, sagaRun.principal, sagaRun.params, step)
         } catch (rethrown: Exception) {
-            notify(Failed(sagaRun, step, ex, null))
+            notify(Failed(sagaRun, step, ex, null, willRestart = false, elapsedSince(startedAt)))
             throw rethrown
         }
-        notify(Failed(sagaRun, step, ex, mapped))
-        return if (mapped == null) SagaOutcome.Restart(ex) else SagaOutcome.Ended(mapped)
+        if (mapped != null) {
+            notify(Failed(sagaRun, step, ex, mapped, willRestart = false, elapsedSince(startedAt)))
+            return SagaOutcome.Ended(mapped)
+        }
+        val backoff = restartAfter(sagaRun.attempt, ex)
+        notify(Failed(sagaRun, step, ex, null, willRestart = backoff != null, elapsedSince(startedAt)))
+        if (backoff == null) {
+            throw ex
+        }
+        return SagaOutcome.Restart(backoff)
     }
 
     private fun recordAttempt(sagaRun: SagaRun<PRINCIPAL, PARAMS>) {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -106,7 +106,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             }
             is StepOutcome.Resolved -> {
                 val nextStep = stepOutcome.step
-                val nextTrail = if (starting) setOf(nextStep::class) else trail + nextStep::class
+                val nextTrail = trail + nextStep::class
                 if (starting) {
                     notify(Resumed(sagaRun, nextStep))
                 } else {
@@ -241,8 +241,8 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private fun countObserverFailure(sagaName: String, ex: Exception) {
         val outcome = if (ex is TimeoutCancellationException) TIMED_OUT else THREW
         runCatching {
-            sagaExecutionContext.recordObserverFailure(sagaName, outcome)
             logger.warn(ex) { "Saga observer failed [$sagaName] [${outcome.value}]" }
+            sagaExecutionContext.recordObserverFailure(sagaName, outcome)
         }
     }
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -163,7 +163,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         startedAt: Long,
     ): TS {
         recordTerminal(terminal)
-        sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.TERMINAL)
+        sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.TERMINAL, terminalName(terminal))
         notify(Terminated(sagaRun, terminal, elapsedSince(startedAt)))
         return terminal
     }
@@ -178,19 +178,19 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         val mapped = try {
             onException(ex, sagaRun.principal, sagaRun.params, step)
         } catch (rethrown: Exception) {
-            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.RETHREW)
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.RETHREW, null)
             notify(Failed(sagaRun, step, ex, null, willRestart = false, elapsedSince(startedAt)))
             throw rethrown
         }
         if (mapped != null) {
-            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.MAPPED)
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.MAPPED, terminalName(mapped))
             notify(Failed(sagaRun, step, ex, mapped, willRestart = false, elapsedSince(startedAt)))
             return SagaOutcome.Ended(mapped)
         }
         val backoff = restartAfter(sagaRun.attempt, ex)
         notify(Failed(sagaRun, step, ex, null, willRestart = backoff != null, elapsedSince(startedAt)))
         if (backoff == null) {
-            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.GAVE_UP)
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.GAVE_UP, null)
             throw ex
         }
         require(backoff.toMillis() > 0) {
@@ -204,9 +204,11 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     }
 
     private fun recordTerminal(terminal: TS): TS {
-        Span.current().setAttribute(SAGA_TERMINAL, terminal::class.simpleName ?: UNKNOWN)
+        Span.current().setAttribute(SAGA_TERMINAL, terminalName(terminal))
         return terminal
     }
+
+    private fun terminalName(terminal: TS) = terminal::class.simpleName ?: UNKNOWN
 
     private fun recordRestart(
         restartedSagaRun: SagaRun<PRINCIPAL, PARAMS>,

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -3,6 +3,8 @@ package com.razz.eva.saga
 import com.razz.eva.saga.Saga.Intermediary
 import com.razz.eva.saga.Saga.Terminal
 import com.razz.eva.domain.Principal
+import com.razz.eva.saga.ObserverOutcome.THREW
+import com.razz.eva.saga.ObserverOutcome.TIMED_OUT
 import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPT
 import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPTS
 import com.razz.eva.saga.OtelAttributes.SAGA_PARENT_RUN_ID
@@ -17,6 +19,7 @@ import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode.ERROR
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -24,7 +27,6 @@ import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.withTimeout
 import mu.KotlinLogging
 import java.time.Duration
-import kotlin.coroutines.cancellation.CancellationException
 import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -214,20 +216,20 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                     withTimeout(sagaExecutionContext.observerTimeout.toMillis().milliseconds) {
                         observer.onNotification(notification)
                     }
-                } catch (ex: TimeoutCancellationException) {
-                    currentCoroutineContext().ensureActive()
-                    countObserverFailure(sagaName, ex, ObserverOutcome.TIMED_OUT)
-                } catch (ex: CancellationException) {
-                    throw ex
                 } catch (ex: Throwable) {
                     currentCoroutineContext().ensureActive()
-                    countObserverFailure(sagaName, ex, ObserverOutcome.THREW)
+                    if (ex !is Exception) {
+                        Span.current().recordException(ex).setStatus(ERROR)
+                        throw ex
+                    }
+                    countObserverFailure(sagaName, ex)
                 }
             }
         }
     }
 
-    private fun countObserverFailure(sagaName: String, ex: Throwable, outcome: ObserverOutcome) {
+    private fun countObserverFailure(sagaName: String, ex: Exception) {
+        val outcome = if (ex is TimeoutCancellationException) TIMED_OUT else THREW
         runCatching {
             sagaExecutionContext.recordObserverFailure(sagaName, outcome)
             logger.warn(ex) { "Saga observer failed [$sagaName] [${outcome.value}]" }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -187,6 +187,9 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         if (backoff == null) {
             throw ex
         }
+        require(backoff.toMillis() > 0) {
+            "Saga restart backoff must be at least a millisecond, but was [$backoff]"
+        }
         return SagaOutcome.Restart(backoff)
     }
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -99,20 +99,21 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         while (true) {
             when (val current = step) {
                 is Intermediary<*> -> {
+                    val currentStep = current as IS
                     val stepStartedAt = System.nanoTime()
                     val nextStep = try {
-                        val resolved = startSagaIntermediateSpan(current::class.simpleName).use {
-                            next(sagaRun.principal, current as IS)
+                        val resolved = startSagaIntermediateSpan(currentStep::class.simpleName).use {
+                            next(sagaRun.principal, currentStep)
                         }
                         if (resolved::class in trail) {
-                            throw SagaHaltException(resolved as IS)
+                            throw SagaHaltException(resolved as Intermediary<*>)
                         }
                         resolved
                     } catch (ex: Exception) {
-                        return failed(sagaRun, current, ex)
+                        return failed(sagaRun, currentStep, ex)
                     }
                     emit(sagaRun.sagaName, Notification.TRANSITION) {
-                        it.onTransition(sagaRun, current, nextStep, elapsedSince(stepStartedAt))
+                        it.onTransition(sagaRun, currentStep, nextStep, elapsedSince(stepStartedAt))
                     }
                     trail = trail + nextStep::class
                     step = nextStep
@@ -128,15 +129,14 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
     private suspend fun failed(
         sagaRun: SagaRun<PRINCIPAL, PARAMS>,
-        step: Step<SELF>?,
+        step: IS?,
         ex: Exception,
     ): SagaOutcome<TS> {
         Span.current().recordException(ex).setStatus(ERROR)
         val mapped = try {
-            onException(ex, sagaRun.principal, sagaRun.params, step as IS?)
+            onException(ex, sagaRun.principal, sagaRun.params, step)
         } catch (rethrown: Exception) {
             emit(sagaRun.sagaName, Notification.FAILED) { it.onFailed(sagaRun, step, ex, null) }
             throw rethrown

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -76,43 +76,44 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     @Suppress("UNCHECKED_CAST")
     private tailrec suspend fun advance(
         sagaRun: SagaRun<PRINCIPAL, PARAMS>,
-        step: IS?,
+        currentStep: IS?,
         trail: Set<KClass<out Step<SELF>>>,
         startedAt: Long,
     ): TS {
         val stepStartedAt = System.nanoTime()
-        val stepOutcome = if (step == null) {
+        val starting = currentStep == null
+        val stepOutcome = if (starting) {
             recordAttempt(sagaRun)
             initialise(sagaRun)
         } else {
-            resolveNext(sagaRun, step, trail)
+            resolveNext(sagaRun, currentStep, trail)
         }
         return when (stepOutcome) {
-            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, step, stepOutcome.ex)) {
+            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex)) {
                 is SagaOutcome.Ended -> recordTerminal(sagaOutcome.terminal)
                 is SagaOutcome.Restart -> {
                     val backoff = restartAfter(sagaRun.attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
-                    val restarted = sagaRun.copy(
+                    val restartedSagaRun = sagaRun.copy(
                         id = SagaRunId.random(),
                         parentId = sagaRun.id,
                         attempt = sagaRun.attempt + 1,
                         sagaName = sagaName,
                     )
-                    recordRestart(restarted, sagaRun.id)
+                    recordRestart(restartedSagaRun, sagaRun.id)
                     delay(backoff.toMillis().milliseconds)
-                    advance(restarted, null, setOf(), System.nanoTime())
+                    advance(restartedSagaRun, null, setOf(), System.nanoTime())
                 }
             }
             is StepOutcome.Resolved -> {
                 val nextStep = stepOutcome.step
-                val nextTrail = if (step == null) setOf(nextStep::class) else trail + nextStep::class
-                if (step == null) {
+                val nextTrail = if (starting) setOf(nextStep::class) else trail + nextStep::class
+                if (starting) {
                     notify(Resumed(sagaRun, nextStep))
                 } else {
                     notify(
                         Transitioned(
                             sagaRun,
-                            step,
+                            currentStep,
                             nextStep,
                             elapsedSince(stepStartedAt),
                         ),
@@ -189,15 +190,15 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         return terminal
     }
 
-    private fun recordRestart(restarted: SagaRun<PRINCIPAL, PARAMS>, parentRunId: SagaRunId) {
-        sagaExecutionContext.recordRestart(restarted.sagaName)
+    private fun recordRestart(restartedSagaRun: SagaRun<PRINCIPAL, PARAMS>, parentRunId: SagaRunId) {
+        sagaExecutionContext.recordRestart(restartedSagaRun.sagaName)
         Span.current()
             .addEvent(
                 Events.RESTART,
                 Attributes.of(
-                    SAGA_RUN_ID, restarted.id.toString(),
+                    SAGA_RUN_ID, restartedSagaRun.id.toString(),
                     SAGA_PARENT_RUN_ID, parentRunId.toString(),
-                    SAGA_ATTEMPT, restarted.attempt.toLong(),
+                    SAGA_ATTEMPT, restartedSagaRun.attempt.toLong(),
                 ),
             )
     }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -178,7 +178,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             throw rethrown
         }
         notify(Failed(sagaRun, step, ex, mapped))
-        return if (mapped != null) SagaOutcome.Ended(mapped) else SagaOutcome.Restart(ex)
+        return if (mapped == null) SagaOutcome.Restart(ex) else SagaOutcome.Ended(mapped)
     }
 
     private fun recordAttempt(sagaRun: SagaRun<PRINCIPAL, PARAMS>) {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -15,8 +15,7 @@ import com.razz.eva.saga.SagaNotification.Failed
 import com.razz.eva.saga.SagaNotification.Resumed
 import com.razz.eva.saga.SagaNotification.Terminated
 import com.razz.eva.saga.SagaNotification.Transitioned
-import com.razz.eva.tracing.getEvaTracer
-import com.razz.eva.tracing.use
+import com.razz.eva.tracing.withSpan
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.StatusCode.ERROR
@@ -70,7 +69,10 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
 
     suspend fun resume(principal: PRINCIPAL, params: PARAMS): TS {
         val sagaRun = SagaRun(SagaRunId.random(), null, 0, sagaName, principal, params)
-        return startSagaRunSpan(sagaRun).use {
+        return sagaExecutionContext.otel.withSpan(
+            spanName = sagaRun.sagaName,
+            parameters = { setAttribute(SAGA_RUN_ID, sagaRun.id.toString()) },
+        ) {
             advance(sagaRun, null, setOf(), System.nanoTime())
         }
     }
@@ -130,7 +132,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private suspend fun resolveFirst(sagaRun: SagaRun<PRINCIPAL, PARAMS>): StepOutcome<Step<SELF>> =
         try {
             StepOutcome.Resolved(
-                startSagaInitSpan(sagaRun.sagaName).use {
+                sagaExecutionContext.otel.withSpan("${sagaRun.sagaName}-init") {
                     init(sagaRun.principal, sagaRun.params)
                 },
             )
@@ -144,7 +146,9 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         trail: Set<KClass<out Step<SELF>>>,
     ): StepOutcome<Step<SELF>> =
         try {
-            val resolved = startSagaIntermediateSpan(currentStep::class.simpleName).use {
+            val resolved = sagaExecutionContext.otel.withSpan(
+                currentStep::class.simpleName?.let { "$it-intermediate" } ?: "SagaIntermediateStep",
+            ) {
                 next(sagaRun.principal, currentStep)
             }
             if (resolved::class in trail) {
@@ -220,7 +224,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             return
         }
         val sagaName = notification.run.sagaName
-        startNotifySpan(notification).use {
+        sagaExecutionContext.otel.withSpan("${notification.run.sagaName}-${notification.suffix}") {
             observers.forEach { observer ->
                 try {
                     withTimeout(sagaExecutionContext.observerTimeout.toMillis().milliseconds) {
@@ -248,25 +252,6 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
 
     private fun elapsedSince(startedAtNanos: Long): Duration =
         Duration.ofNanos(System.nanoTime() - startedAtNanos)
-
-    private fun startSagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>) =
-        sagaExecutionContext.otel.getEvaTracer()
-            .spanBuilder(sagaRun.sagaName)
-            .setAttribute(SAGA_RUN_ID, sagaRun.id.toString())
-            .startSpan()
-
-    private fun startNotifySpan(notification: SagaNotification<PRINCIPAL, PARAMS>) =
-        sagaExecutionContext.otel.getEvaTracer()
-            .spanBuilder("${notification.run.sagaName}-${notification.suffix}")
-            .startSpan()
-
-    private fun startSagaInitSpan(sagaName: String) = sagaExecutionContext.otel.getEvaTracer()
-        .spanBuilder("$sagaName-init")
-        .startSpan()
-
-    private fun startSagaIntermediateSpan(stepName: String?) = sagaExecutionContext.otel.getEvaTracer()
-        .spanBuilder(stepName?.let { "$it-intermediate" } ?: "SagaIntermediateStep")
-        .startSpan()
 
     private val logger = KotlinLogging.logger {}
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -34,22 +34,22 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private val sagaExecutionContext: SagaExecutionContext = sagaExecutionContext(),
     private val observers: List<SagaObserver<PRINCIPAL, PARAMS>> = listOf(),
 )
-        where PRINCIPAL : Principal<*>,
-              IS : Intermediary<SELF>,
-              TS : Terminal<SELF>,
-              SELF : Saga<PRINCIPAL, PARAMS, IS, TS, SELF> {
+    where PRINCIPAL : Principal<*>,
+          IS : Intermediary<SELF>,
+          TS : Terminal<SELF>,
+          SELF : Saga<PRINCIPAL, PARAMS, IS, TS, SELF> {
 
     class SagaHaltException(step: Intermediary<*>) :
         IllegalStateException("Saga step [${step::class.simpleName}] already seen")
 
     sealed interface Step<SAGA>
-            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     interface Intermediary<SAGA> : Step<SAGA>
-            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     interface Terminal<SAGA> : Step<SAGA>
-            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     protected abstract suspend fun init(principal: PRINCIPAL, params: PARAMS): Step<SELF>
 
@@ -78,23 +78,19 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     @Suppress("UNCHECKED_CAST")
     private tailrec suspend fun advance(
         sagaRun: SagaRun<PRINCIPAL, PARAMS>,
-        step: Step<SELF>?,
+        step: IS?,
         trail: Set<KClass<out Step<SELF>>>,
         startedAt: Long,
     ): TS {
-        if (step is Terminal<*>) {
-            return terminated(sagaRun, step as TS, startedAt)
-        }
-        val currentStep = step as IS?
         val stepStartedAt = System.nanoTime()
-        val stepOutcome = if (currentStep == null) {
+        val stepOutcome = if (step == null) {
             recordAttempt(sagaRun)
             initialise(sagaRun)
         } else {
-            resolveNext(sagaRun, currentStep, trail)
+            resolveNext(sagaRun, step, trail)
         }
         return when (stepOutcome) {
-            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex)) {
+            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, step, stepOutcome.ex)) {
                 is Ended -> recordTerminal(sagaOutcome.terminal)
                 is Restart -> {
                     val backoff = restartAfter(sagaRun.attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
@@ -112,19 +108,22 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
 
             is StepOutcome.Resolved -> {
                 val nextStep = stepOutcome.step
-                if (currentStep == null) {
+                val nextTrail = if (step == null) setOf(nextStep::class) else trail + nextStep::class
+                if (step == null) {
                     notify(Resumed(sagaRun, nextStep))
-                    advance(sagaRun, nextStep, setOf(nextStep::class), startedAt)
                 } else {
                     notify(
                         Transitioned(
                             sagaRun,
-                            currentStep,
+                            step,
                             nextStep,
-                            elapsedSince(stepStartedAt)
+                            elapsedSince(stepStartedAt),
                         ),
                     )
-                    advance(sagaRun, nextStep, trail + nextStep::class, startedAt)
+                }
+                when (nextStep) {
+                    is Terminal<*> -> terminated(sagaRun, nextStep as TS, startedAt)
+                    is Intermediary<*> -> advance(sagaRun, nextStep as IS, nextTrail, startedAt)
                 }
             }
         }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -43,10 +43,8 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
 
     sealed interface Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
-
     interface Intermediary<SAGA> : Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
-
     interface Terminal<SAGA> : Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -4,16 +4,21 @@ import com.razz.eva.saga.Saga.Intermediary
 import com.razz.eva.saga.Saga.Terminal
 import com.razz.eva.domain.Principal
 import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPT
+import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPTS
 import com.razz.eva.saga.OtelAttributes.SAGA_PARENT_RUN_ID
 import com.razz.eva.saga.OtelAttributes.SAGA_RUN_ID
 import com.razz.eva.saga.OtelAttributes.SAGA_TERMINAL
 import com.razz.eva.saga.OtelAttributes.UNKNOWN_TERMINAL
+import com.razz.eva.saga.SagaNotification.Failed
+import com.razz.eva.saga.SagaNotification.Resumed
+import com.razz.eva.saga.SagaNotification.Terminated
+import com.razz.eva.saga.SagaNotification.Transitioned
 import com.razz.eva.saga.SagaOutcome.Ended
 import com.razz.eva.saga.SagaOutcome.Restart
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
+import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.trace.Span
-import io.opentelemetry.api.trace.StatusCode.ERROR
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
@@ -22,6 +27,7 @@ import kotlinx.coroutines.withTimeout
 import mu.KotlinLogging
 import java.time.Duration
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.reflect.KClass
 import kotlin.time.Duration.Companion.milliseconds
 
 abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
@@ -63,70 +69,113 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         RESTART_BACKOFF.takeIf { attempt < MAX_RESTARTS }
 
     suspend fun resume(principal: PRINCIPAL, params: PARAMS): TS {
-        var currentId = SagaRunId.random()
-        var currentParentId: SagaRunId? = null
-        var attempt = 0
-        while (true) {
-            val name = sagaName
-            val sagaRun = SagaRun(currentId, currentParentId, name, principal, params)
-            val outcome = startSagaRunSpan(sagaRun, attempt).use { runOnce(sagaRun) }
-            when (outcome) {
-                is Ended -> {
-                    return outcome.terminal
-                }
+        val sagaRun = SagaRun(SagaRunId.random(), null, sagaName, principal, params)
+        return startSagaRunSpan(sagaRun).use { advance(sagaRun, 0, null, setOf(), System.nanoTime()) }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private tailrec suspend fun advance(
+        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        attempt: Int,
+        step: Step<SELF>?,
+        trail: Set<KClass<out Step<SELF>>>,
+        startedAt: Long,
+    ): TS {
+        if (step is Terminal<*>) {
+            return terminated(sagaRun, step as TS, startedAt)
+        }
+        val currentStep = step as IS?
+        val stepStartedAt = System.nanoTime()
+        val stepOutcome = if (currentStep == null) {
+            recordAttempt(attempt)
+            initialise(sagaRun)
+        } else {
+            resolveNext(sagaRun, currentStep, trail)
+        }
+        return when (stepOutcome) {
+            is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex)) {
+                is Ended -> recordTerminal(sagaOutcome.terminal)
                 is Restart -> {
-                    val backoff = restartAfter(attempt, outcome.cause) ?: throw outcome.cause
-                    sagaExecutionContext.recordRestart(name)
+                    val backoff = restartAfter(attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
+                    val restarted = sagaRun.copy(
+                        id = SagaRunId.random(),
+                        parentId = sagaRun.id,
+                        sagaName = sagaName,
+                    )
+                    recordRestart(restarted.sagaName, restarted.id, sagaRun.id, attempt + 1)
                     delay(backoff.toMillis().milliseconds)
-                    attempt += 1
-                    currentParentId = currentId
-                    currentId = SagaRunId.random()
+                    advance(restarted, attempt + 1, null, setOf(), System.nanoTime())
+                }
+            }
+            is StepOutcome.Resolved -> {
+                val nextStep = stepOutcome.step
+                if (currentStep == null) {
+                    notify(Resumed(sagaRun, nextStep))
+                    advance(sagaRun, attempt, nextStep, setOf(nextStep::class), startedAt)
+                } else {
+                    notify(Transitioned(sagaRun, currentStep, nextStep, elapsedSince(stepStartedAt)))
+                    advance(sagaRun, attempt, nextStep, trail + nextStep::class, startedAt)
                 }
             }
         }
     }
 
-    @Suppress("UNCHECKED_CAST")
-    private suspend fun runOnce(sagaRun: SagaRun<PRINCIPAL, PARAMS>): SagaOutcome<TS> {
-        val startedAt = System.nanoTime()
-        var step = try {
-            startSagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) }
+    private suspend fun initialise(sagaRun: SagaRun<PRINCIPAL, PARAMS>): StepOutcome<Step<SELF>> =
+        try {
+            StepOutcome.Resolved(
+                startSagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) },
+            )
         } catch (ex: Exception) {
-            return failed(sagaRun, null, ex)
+            StepOutcome.Threw(ex)
         }
-        emit(sagaRun.sagaName, Notification.RESUMED) { it.onResumed(sagaRun, step) }
-        var trail = setOf(step::class)
-        while (true) {
-            when (val current = step) {
-                is Intermediary<*> -> {
-                    val currentStep = current as IS
-                    val stepStartedAt = System.nanoTime()
-                    val nextStep = try {
-                        val resolved = startSagaIntermediateSpan(currentStep::class.simpleName).use {
-                            next(sagaRun.principal, currentStep)
-                        }
-                        if (resolved::class in trail) {
-                            throw SagaHaltException(resolved as Intermediary<*>)
-                        }
-                        resolved
-                    } catch (ex: Exception) {
-                        return failed(sagaRun, currentStep, ex)
-                    }
-                    emit(sagaRun.sagaName, Notification.TRANSITION) {
-                        it.onTransition(sagaRun, currentStep, nextStep, elapsedSince(stepStartedAt))
-                    }
-                    trail = trail + nextStep::class
-                    step = nextStep
-                }
-                is Terminal<*> -> {
-                    Span.current().setAttribute(SAGA_TERMINAL, current::class.simpleName ?: UNKNOWN_TERMINAL)
-                    emit(sagaRun.sagaName, Notification.TERMINATED) {
-                        it.onTerminated(sagaRun, current, elapsedSince(startedAt))
-                    }
-                    return Ended(current as TS)
-                }
+
+    private suspend fun resolveNext(
+        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        currentStep: IS,
+        trail: Set<KClass<out Step<SELF>>>,
+    ): StepOutcome<Step<SELF>> =
+        try {
+            val resolved = startSagaIntermediateSpan(currentStep::class.simpleName).use {
+                next(sagaRun.principal, currentStep)
             }
+            if (resolved::class in trail) {
+                throw SagaHaltException(resolved as Intermediary<*>)
+            }
+            StepOutcome.Resolved(resolved)
+        } catch (ex: Exception) {
+            StepOutcome.Threw(ex)
         }
+
+    private suspend fun terminated(
+        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        terminal: TS,
+        startedAt: Long,
+    ): TS {
+        recordTerminal(terminal)
+        notify(Terminated(sagaRun, terminal, elapsedSince(startedAt)))
+        return terminal
+    }
+
+    private fun recordAttempt(attempt: Int) {
+        Span.current().setAttribute(SAGA_ATTEMPTS, (attempt + 1).toLong())
+    }
+
+    private fun recordTerminal(terminal: TS): TS {
+        Span.current().setAttribute(SAGA_TERMINAL, terminal::class.simpleName ?: UNKNOWN_TERMINAL)
+        return terminal
+    }
+
+    private fun recordRestart(sagaName: String, runId: SagaRunId, parentRunId: SagaRunId, attempt: Int) {
+        sagaExecutionContext.recordRestart(sagaName)
+        Span.current()
+            .addEvent(
+                Events.RESTART,
+                Attributes.of(
+                    SAGA_RUN_ID, runId.toString(),
+                    SAGA_PARENT_RUN_ID, parentRunId.toString(),
+                    SAGA_ATTEMPT, attempt.toLong(),
+                ),
+            )
     }
 
     private suspend fun failed(
@@ -134,45 +183,37 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         step: IS?,
         ex: Exception,
     ): SagaOutcome<TS> {
-        Span.current().recordException(ex).setStatus(ERROR)
+        Span.current().recordException(ex)
         val mapped = try {
             onException(ex, sagaRun.principal, sagaRun.params, step)
         } catch (rethrown: Exception) {
-            emit(sagaRun.sagaName, Notification.FAILED) { it.onFailed(sagaRun, step, ex, null) }
+            notify(Failed(sagaRun, step, ex, null))
             throw rethrown
         }
-        emit(sagaRun.sagaName, Notification.FAILED) { it.onFailed(sagaRun, step, ex, mapped) }
+        notify(Failed(sagaRun, step, ex, mapped))
         return if (mapped != null) Ended(mapped) else Restart(ex)
     }
 
-    private suspend fun emit(
-        sagaName: String,
-        notification: Notification,
-        notify: suspend (SagaObserver<PRINCIPAL, PARAMS>) -> Unit,
-    ) {
+    private suspend fun notify(notification: SagaNotification<PRINCIPAL, PARAMS>) {
         if (observers.isEmpty()) {
             return
         }
-        startNotifySpan(sagaName, notification).use {
-            notifyEach(sagaName, notify)
-        }
-    }
-
-    private suspend fun notifyEach(
-        sagaName: String,
-        notify: suspend (SagaObserver<PRINCIPAL, PARAMS>) -> Unit,
-    ) {
-        observers.forEach { observer ->
-            try {
-                withTimeout(sagaExecutionContext.observerTimeout.toMillis().milliseconds) { notify(observer) }
-            } catch (ex: TimeoutCancellationException) {
-                currentCoroutineContext().ensureActive()
-                countObserverFailure(sagaName, ex, ObserverOutcome.TIMED_OUT)
-            } catch (ex: CancellationException) {
-                throw ex
-            } catch (ex: Throwable) {
-                currentCoroutineContext().ensureActive()
-                countObserverFailure(sagaName, ex, ObserverOutcome.THREW)
+        val sagaName = notification.run.sagaName
+        startNotifySpan(notification).use {
+            observers.forEach { observer ->
+                try {
+                    withTimeout(sagaExecutionContext.observerTimeout.toMillis().milliseconds) {
+                        observer.onNotification(notification)
+                    }
+                } catch (ex: TimeoutCancellationException) {
+                    currentCoroutineContext().ensureActive()
+                    countObserverFailure(sagaName, ex, ObserverOutcome.TIMED_OUT)
+                } catch (ex: CancellationException) {
+                    throw ex
+                } catch (ex: Throwable) {
+                    currentCoroutineContext().ensureActive()
+                    countObserverFailure(sagaName, ex, ObserverOutcome.THREW)
+                }
             }
         }
     }
@@ -187,17 +228,15 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private fun elapsedSince(startedAtNanos: Long): Duration =
         Duration.ofNanos(System.nanoTime() - startedAtNanos)
 
-    private fun startSagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>, attempt: Int) =
+    private fun startSagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>) =
         sagaExecutionContext.otel.getEvaTracer()
             .spanBuilder(sagaRun.sagaName)
             .setAttribute(SAGA_RUN_ID, sagaRun.id.toString())
-            .setAttribute(SAGA_ATTEMPT, attempt.toLong())
-            .apply { sagaRun.parentId?.let { setAttribute(SAGA_PARENT_RUN_ID, it.toString()) } }
             .startSpan()
 
-    private fun startNotifySpan(sagaName: String, notification: Notification) =
+    private fun startNotifySpan(notification: SagaNotification<PRINCIPAL, PARAMS>) =
         sagaExecutionContext.otel.getEvaTracer()
-            .spanBuilder("$sagaName-${notification.suffix}")
+            .spanBuilder("${notification.run.sagaName}-${notification.suffix}")
             .startSpan()
 
     private fun startSagaInitSpan(sagaName: String) = sagaExecutionContext.otel.getEvaTracer()
@@ -214,4 +253,9 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         private const val MAX_RESTARTS = 2
         private val RESTART_BACKOFF = Duration.ofMillis(100)
     }
+}
+
+private sealed interface StepOutcome<out STEP> {
+    class Resolved<STEP>(val step: STEP) : StepOutcome<STEP>
+    class Threw(val ex: Exception) : StepOutcome<Nothing>
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -10,7 +10,7 @@ import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPTS
 import com.razz.eva.saga.OtelAttributes.SAGA_PARENT_RUN_ID
 import com.razz.eva.saga.OtelAttributes.SAGA_RUN_ID
 import com.razz.eva.saga.OtelAttributes.SAGA_TERMINAL
-import com.razz.eva.saga.OtelAttributes.UNKNOWN_TERMINAL
+import com.razz.eva.saga.OtelAttributes.UNKNOWN
 import com.razz.eva.saga.SagaNotification.Failed
 import com.razz.eva.saga.SagaNotification.Resumed
 import com.razz.eva.saga.SagaNotification.Terminated
@@ -101,7 +101,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                         parentId = sagaRun.id,
                         attempt = sagaRun.attempt + 1,
                     )
-                    recordRestart(restartedSagaRun, sagaRun.id)
+                    recordRestart(restartedSagaRun, sagaRun.id, stepOutcome.ex)
                     delay(sagaOutcome.backoff.toMillis().milliseconds)
                     advance(restartedSagaRun, null, setOf(), System.nanoTime())
                 }
@@ -165,6 +165,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         startedAt: Long,
     ): TS {
         recordTerminal(terminal)
+        sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.TERMINAL)
         notify(Terminated(sagaRun, terminal, elapsedSince(startedAt)))
         return terminal
     }
@@ -179,16 +180,19 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         val mapped = try {
             onException(ex, sagaRun.principal, sagaRun.params, step)
         } catch (rethrown: Exception) {
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.RETHREW)
             notify(Failed(sagaRun, step, ex, null, willRestart = false, elapsedSince(startedAt)))
             throw rethrown
         }
         if (mapped != null) {
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.MAPPED)
             notify(Failed(sagaRun, step, ex, mapped, willRestart = false, elapsedSince(startedAt)))
             return SagaOutcome.Ended(mapped)
         }
         val backoff = restartAfter(sagaRun.attempt, ex)
         notify(Failed(sagaRun, step, ex, null, willRestart = backoff != null, elapsedSince(startedAt)))
         if (backoff == null) {
+            sagaExecutionContext.recordOutcome(sagaRun.sagaName, RunOutcome.GAVE_UP)
             throw ex
         }
         require(backoff.toMillis() > 0) {
@@ -202,12 +206,20 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     }
 
     private fun recordTerminal(terminal: TS): TS {
-        Span.current().setAttribute(SAGA_TERMINAL, terminal::class.simpleName ?: UNKNOWN_TERMINAL)
+        Span.current().setAttribute(SAGA_TERMINAL, terminal::class.simpleName ?: UNKNOWN)
         return terminal
     }
 
-    private fun recordRestart(restartedSagaRun: SagaRun<PRINCIPAL, PARAMS>, parentRunId: SagaRunId) {
-        sagaExecutionContext.recordRestart(restartedSagaRun.sagaName)
+    private fun recordRestart(
+        restartedSagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        parentRunId: SagaRunId,
+        cause: Exception,
+    ) {
+        sagaExecutionContext.recordRestart(
+            restartedSagaRun.sagaName,
+            restartedSagaRun.attempt,
+            cause::class.simpleName ?: UNKNOWN,
+        )
         Span.current()
             .addEvent(
                 Events.RESTART,

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -13,8 +13,6 @@ import com.razz.eva.saga.SagaNotification.Failed
 import com.razz.eva.saga.SagaNotification.Resumed
 import com.razz.eva.saga.SagaNotification.Terminated
 import com.razz.eva.saga.SagaNotification.Transitioned
-import com.razz.eva.saga.SagaOutcome.Ended
-import com.razz.eva.saga.SagaOutcome.Restart
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
 import io.opentelemetry.api.common.Attributes
@@ -91,8 +89,8 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         }
         return when (stepOutcome) {
             is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, step, stepOutcome.ex)) {
-                is Ended -> recordTerminal(sagaOutcome.terminal)
-                is Restart -> {
+                is SagaOutcome.Ended -> recordTerminal(sagaOutcome.terminal)
+                is SagaOutcome.Restart -> {
                     val backoff = restartAfter(sagaRun.attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
                     val restarted = sagaRun.copy(
                         id = SagaRunId.random(),
@@ -167,6 +165,22 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         return terminal
     }
 
+    private suspend fun failed(
+        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        step: IS?,
+        ex: Exception,
+    ): SagaOutcome<TS> {
+        Span.current().recordException(ex)
+        val mapped = try {
+            onException(ex, sagaRun.principal, sagaRun.params, step)
+        } catch (rethrown: Exception) {
+            notify(Failed(sagaRun, step, ex, null))
+            throw rethrown
+        }
+        notify(Failed(sagaRun, step, ex, mapped))
+        return if (mapped != null) SagaOutcome.Ended(mapped) else SagaOutcome.Restart(ex)
+    }
+
     private fun recordAttempt(sagaRun: SagaRun<PRINCIPAL, PARAMS>) {
         Span.current().setAttribute(SAGA_ATTEMPTS, (sagaRun.attempt + 1).toLong())
     }
@@ -187,22 +201,6 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                     SAGA_ATTEMPT, restarted.attempt.toLong(),
                 ),
             )
-    }
-
-    private suspend fun failed(
-        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
-        step: IS?,
-        ex: Exception,
-    ): SagaOutcome<TS> {
-        Span.current().recordException(ex)
-        val mapped = try {
-            onException(ex, sagaRun.principal, sagaRun.params, step)
-        } catch (rethrown: Exception) {
-            notify(Failed(sagaRun, step, ex, null))
-            throw rethrown
-        }
-        notify(Failed(sagaRun, step, ex, mapped))
-        return if (mapped != null) Ended(mapped) else Restart(ex)
     }
 
     private suspend fun notify(notification: SagaNotification<PRINCIPAL, PARAMS>) {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -34,22 +34,22 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private val sagaExecutionContext: SagaExecutionContext = sagaExecutionContext(),
     private val observers: List<SagaObserver<PRINCIPAL, PARAMS>> = listOf(),
 )
-    where PRINCIPAL : Principal<*>,
-          IS : Intermediary<SELF>,
-          TS : Terminal<SELF>,
-          SELF : Saga<PRINCIPAL, PARAMS, IS, TS, SELF> {
+        where PRINCIPAL : Principal<*>,
+              IS : Intermediary<SELF>,
+              TS : Terminal<SELF>,
+              SELF : Saga<PRINCIPAL, PARAMS, IS, TS, SELF> {
 
     class SagaHaltException(step: Intermediary<*>) :
         IllegalStateException("Saga step [${step::class.simpleName}] already seen")
 
     sealed interface Step<SAGA>
-        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     interface Intermediary<SAGA> : Step<SAGA>
-        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     interface Terminal<SAGA> : Step<SAGA>
-        where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+            where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
     protected abstract suspend fun init(principal: PRINCIPAL, params: PARAMS): Step<SELF>
 
@@ -69,14 +69,15 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         RESTART_BACKOFF.takeIf { attempt < MAX_RESTARTS }
 
     suspend fun resume(principal: PRINCIPAL, params: PARAMS): TS {
-        val sagaRun = SagaRun(SagaRunId.random(), null, sagaName, principal, params)
-        return startSagaRunSpan(sagaRun).use { advance(sagaRun, 0, null, setOf(), System.nanoTime()) }
+        val sagaRun = SagaRun(SagaRunId.random(), null, 0, sagaName, principal, params)
+        return startSagaRunSpan(sagaRun).use {
+            advance(sagaRun, null, setOf(), System.nanoTime())
+        }
     }
 
     @Suppress("UNCHECKED_CAST")
     private tailrec suspend fun advance(
         sagaRun: SagaRun<PRINCIPAL, PARAMS>,
-        attempt: Int,
         step: Step<SELF>?,
         trail: Set<KClass<out Step<SELF>>>,
         startedAt: Long,
@@ -87,7 +88,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         val currentStep = step as IS?
         val stepStartedAt = System.nanoTime()
         val stepOutcome = if (currentStep == null) {
-            recordAttempt(attempt)
+            recordAttempt(sagaRun)
             initialise(sagaRun)
         } else {
             resolveNext(sagaRun, currentStep, trail)
@@ -96,25 +97,34 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             is StepOutcome.Threw -> when (val sagaOutcome = failed(sagaRun, currentStep, stepOutcome.ex)) {
                 is Ended -> recordTerminal(sagaOutcome.terminal)
                 is Restart -> {
-                    val backoff = restartAfter(attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
+                    val backoff = restartAfter(sagaRun.attempt, sagaOutcome.cause) ?: throw sagaOutcome.cause
                     val restarted = sagaRun.copy(
                         id = SagaRunId.random(),
                         parentId = sagaRun.id,
+                        attempt = sagaRun.attempt + 1,
                         sagaName = sagaName,
                     )
-                    recordRestart(restarted.sagaName, restarted.id, sagaRun.id, attempt + 1)
+                    recordRestart(restarted, sagaRun.id)
                     delay(backoff.toMillis().milliseconds)
-                    advance(restarted, attempt + 1, null, setOf(), System.nanoTime())
+                    advance(restarted, null, setOf(), System.nanoTime())
                 }
             }
+
             is StepOutcome.Resolved -> {
                 val nextStep = stepOutcome.step
                 if (currentStep == null) {
                     notify(Resumed(sagaRun, nextStep))
-                    advance(sagaRun, attempt, nextStep, setOf(nextStep::class), startedAt)
+                    advance(sagaRun, nextStep, setOf(nextStep::class), startedAt)
                 } else {
-                    notify(Transitioned(sagaRun, currentStep, nextStep, elapsedSince(stepStartedAt)))
-                    advance(sagaRun, attempt, nextStep, trail + nextStep::class, startedAt)
+                    notify(
+                        Transitioned(
+                            sagaRun,
+                            currentStep,
+                            nextStep,
+                            elapsedSince(stepStartedAt)
+                        ),
+                    )
+                    advance(sagaRun, nextStep, trail + nextStep::class, startedAt)
                 }
             }
         }
@@ -123,7 +133,9 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private suspend fun initialise(sagaRun: SagaRun<PRINCIPAL, PARAMS>): StepOutcome<Step<SELF>> =
         try {
             StepOutcome.Resolved(
-                startSagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) },
+                startSagaInitSpan(sagaRun.sagaName).use {
+                    init(sagaRun.principal, sagaRun.params)
+                },
             )
         } catch (ex: Exception) {
             StepOutcome.Threw(ex)
@@ -156,8 +168,8 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         return terminal
     }
 
-    private fun recordAttempt(attempt: Int) {
-        Span.current().setAttribute(SAGA_ATTEMPTS, (attempt + 1).toLong())
+    private fun recordAttempt(sagaRun: SagaRun<PRINCIPAL, PARAMS>) {
+        Span.current().setAttribute(SAGA_ATTEMPTS, (sagaRun.attempt + 1).toLong())
     }
 
     private fun recordTerminal(terminal: TS): TS {
@@ -165,15 +177,15 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         return terminal
     }
 
-    private fun recordRestart(sagaName: String, runId: SagaRunId, parentRunId: SagaRunId, attempt: Int) {
-        sagaExecutionContext.recordRestart(sagaName)
+    private fun recordRestart(restarted: SagaRun<PRINCIPAL, PARAMS>, parentRunId: SagaRunId) {
+        sagaExecutionContext.recordRestart(restarted.sagaName)
         Span.current()
             .addEvent(
                 Events.RESTART,
                 Attributes.of(
-                    SAGA_RUN_ID, runId.toString(),
+                    SAGA_RUN_ID, restarted.id.toString(),
                     SAGA_PARENT_RUN_ID, parentRunId.toString(),
-                    SAGA_ATTEMPT, attempt.toLong(),
+                    SAGA_ATTEMPT, restarted.attempt.toLong(),
                 ),
             )
     }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -3,12 +3,30 @@ package com.razz.eva.saga
 import com.razz.eva.saga.Saga.Intermediary
 import com.razz.eva.saga.Saga.Terminal
 import com.razz.eva.domain.Principal
+import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPT
+import com.razz.eva.saga.OtelAttributes.SAGA_PARENT_RUN_ID
+import com.razz.eva.saga.OtelAttributes.SAGA_RUN_ID
+import com.razz.eva.saga.OtelAttributes.SAGA_TERMINAL
+import com.razz.eva.saga.OtelAttributes.UNKNOWN_TERMINAL
+import com.razz.eva.saga.SagaOutcome.Ended
+import com.razz.eva.saga.SagaOutcome.Restart
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
-import kotlin.reflect.KClass
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.api.trace.StatusCode.ERROR
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.withTimeout
+import mu.KotlinLogging
+import java.time.Duration
+import kotlin.coroutines.cancellation.CancellationException
+import kotlin.time.Duration.Companion.milliseconds
 
 abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private val sagaExecutionContext: SagaExecutionContext = sagaExecutionContext(),
+    private val observers: List<SagaObserver<PRINCIPAL, PARAMS>> = listOf(),
 )
     where PRINCIPAL : Principal<*>,
           IS : Intermediary<SELF>,
@@ -20,8 +38,10 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
 
     sealed interface Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+
     interface Intermediary<SAGA> : Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
+
     interface Terminal<SAGA> : Step<SAGA>
         where SAGA : Saga<*, *, out Intermediary<SAGA>, out Terminal<SAGA>, SAGA>
 
@@ -36,45 +56,167 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         currentStep: IS?,
     ): TS? = throw ex
 
+    protected open val sagaName: String
+        get() = this::class.simpleName ?: "Saga"
+
+    protected open suspend fun restartAfter(attempt: Int, ex: Exception): Duration? =
+        RESTART_BACKOFF.takeIf { attempt < MAX_RESTARTS }
+
     suspend fun resume(principal: PRINCIPAL, params: PARAMS): TS {
-        val initial = try {
-            init(principal, params)
-        } catch (ex: Exception) {
-            onException(ex, principal, params, null) ?: resume(principal, params)
+        var currentId = SagaRunId.random()
+        var currentParentId: SagaRunId? = null
+        var attempt = 0
+        while (true) {
+            val name = sagaName
+            val sagaRun = SagaRun(currentId, currentParentId, name, principal, params)
+            val runSpan = sagaRunSpan(sagaRun, attempt)
+            val outcome = runSpan.use {
+                runOnce(sagaRun).also { outcome ->
+                    if (outcome is Ended) {
+                        runSpan.setAttribute(SAGA_TERMINAL, outcome.terminal::class.simpleName ?: UNKNOWN_TERMINAL)
+                    }
+                }
+            }
+            when (outcome) {
+                is Ended -> return outcome.terminal
+                is Restart -> {
+                    val backoff = restartAfter(attempt, outcome.cause) ?: throw outcome.cause
+                    sagaExecutionContext.recordRestart(name)
+                    delay(backoff.toMillis().milliseconds)
+                    attempt += 1
+                    currentParentId = currentId
+                    currentId = SagaRunId.random()
+                }
+            }
         }
-        return run(principal, params, setOf(initial::class), initial)
     }
 
     @Suppress("UNCHECKED_CAST")
-    private suspend fun run(
-        principal: PRINCIPAL,
-        params: PARAMS,
-        trail: Set<KClass<out Step<SELF>>>,
-        step: Step<SELF>,
-    ): TS = try {
-        when (step) {
-            is Intermediary<*> -> {
-                val nextStep = sagaIntermediateSpan(step::class.simpleName).use {
-                    next(principal, step as IS)
+    private suspend fun runOnce(sagaRun: SagaRun<PRINCIPAL, PARAMS>): SagaOutcome<TS> {
+        val startedAt = System.nanoTime()
+        var step = try {
+            sagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) }
+        } catch (ex: Exception) {
+            return failed(sagaRun, null, ex)
+        }
+        emit(sagaRun.sagaName, Notification.RESUMED) { it.onResumed(sagaRun, step) }
+        var trail = setOf(step::class)
+        while (true) {
+            when (val current = step) {
+                is Intermediary<*> -> {
+                    val stepStartedAt = System.nanoTime()
+                    val nextStep = try {
+                        val resolved = sagaIntermediateSpan(current::class.simpleName).use {
+                            next(sagaRun.principal, current as IS)
+                        }
+                        if (resolved::class in trail) {
+                            throw SagaHaltException(resolved as IS)
+                        }
+                        resolved
+                    } catch (ex: Exception) {
+                        return failed(sagaRun, current, ex)
+                    }
+                    emit(sagaRun.sagaName, Notification.TRANSITION) {
+                        it.onTransition(sagaRun, current, nextStep, elapsedSince(stepStartedAt))
+                    }
+                    trail = trail + nextStep::class
+                    step = nextStep
                 }
-                if (nextStep::class in trail) {
-                    throw SagaHaltException(nextStep as IS)
+
+                is Terminal<*> -> {
+                    emit(sagaRun.sagaName, Notification.TERMINATED) {
+                        it.onTerminated(sagaRun, current, elapsedSince(startedAt))
+                    }
+                    return Ended(current as TS)
                 }
-                run(principal, params, trail + nextStep::class, nextStep)
-            }
-            is Terminal<*> -> sagaTerminalSpan(step::class.simpleName).use {
-                step as TS
             }
         }
-    } catch (ex: Exception) {
-        onException(ex, principal, params, step as IS) ?: resume(principal, params)
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private suspend fun failed(
+        sagaRun: SagaRun<PRINCIPAL, PARAMS>,
+        step: Step<SELF>?,
+        ex: Exception,
+    ): SagaOutcome<TS> {
+        Span.current().recordException(ex).setStatus(ERROR)
+        val mapped = try {
+            onException(ex, sagaRun.principal, sagaRun.params, step as IS?)
+        } catch (rethrown: Exception) {
+            emit(sagaRun.sagaName, Notification.FAILED) { it.onFailed(sagaRun, step, ex, null) }
+            throw rethrown
+        }
+        emit(sagaRun.sagaName, Notification.FAILED) { it.onFailed(sagaRun, step, ex, mapped) }
+        return if (mapped != null) Ended(mapped) else Restart(ex)
+    }
+
+    private suspend fun emit(
+        sagaName: String,
+        notification: Notification,
+        notify: suspend (SagaObserver<PRINCIPAL, PARAMS>) -> Unit,
+    ) {
+        if (observers.isEmpty()) {
+            return
+        }
+        notifySpan(sagaName, notification).use {
+            notifyEach(sagaName, notify)
+        }
+    }
+
+    private suspend fun notifyEach(
+        sagaName: String,
+        notify: suspend (SagaObserver<PRINCIPAL, PARAMS>) -> Unit,
+    ) {
+        observers.forEach { observer ->
+            try {
+                withTimeout(sagaExecutionContext.observerTimeout.toMillis().milliseconds) { notify(observer) }
+            } catch (ex: TimeoutCancellationException) {
+                currentCoroutineContext().ensureActive()
+                countObserverFailure(sagaName, ex, ObserverOutcome.TIMED_OUT)
+            } catch (ex: CancellationException) {
+                throw ex
+            } catch (ex: Throwable) {
+                currentCoroutineContext().ensureActive()
+                countObserverFailure(sagaName, ex, ObserverOutcome.THREW)
+            }
+        }
+    }
+
+    private fun countObserverFailure(sagaName: String, ex: Throwable, outcome: ObserverOutcome) {
+        runCatching {
+            sagaExecutionContext.recordObserverFailure(sagaName, outcome)
+            logger.warn(ex) { "Saga observer failed [$sagaName] [${outcome.value}]" }
+        }
+    }
+
+    private fun elapsedSince(startedAtNanos: Long): Duration =
+        Duration.ofNanos(System.nanoTime() - startedAtNanos)
+
+    private fun sagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>, attempt: Int) =
+        sagaExecutionContext.otel.getEvaTracer()
+            .spanBuilder(sagaRun.sagaName)
+            .setAttribute(SAGA_RUN_ID, sagaRun.id.toString())
+            .setAttribute(SAGA_ATTEMPT, attempt.toLong())
+            .apply { sagaRun.parentId?.let { setAttribute(SAGA_PARENT_RUN_ID, it.toString()) } }
+            .startSpan()
+
+    private fun notifySpan(sagaName: String, notification: Notification) =
+        sagaExecutionContext.otel.getEvaTracer()
+            .spanBuilder("$sagaName-${notification.suffix}")
+            .startSpan()
+
+    private fun sagaInitSpan(sagaName: String) = sagaExecutionContext.otel.getEvaTracer()
+        .spanBuilder("$sagaName-init")
+        .startSpan()
 
     private fun sagaIntermediateSpan(stepName: String?) = sagaExecutionContext.otel.getEvaTracer()
         .spanBuilder(stepName?.let { "$it-intermediate" } ?: "SagaIntermediateStep")
         .startSpan()
 
-    private fun sagaTerminalSpan(stepName: String?) = sagaExecutionContext.otel.getEvaTracer()
-        .spanBuilder(stepName?.let { "$it-terminal" } ?: "SagaTerminalStep")
-        .startSpan()
+    private val logger = KotlinLogging.logger {}
+
+    private companion object {
+        private const val MAX_RESTARTS = 2
+        private val RESTART_BACKOFF = Duration.ofMillis(100)
+    }
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Saga.kt
@@ -69,16 +69,11 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         while (true) {
             val name = sagaName
             val sagaRun = SagaRun(currentId, currentParentId, name, principal, params)
-            val runSpan = sagaRunSpan(sagaRun, attempt)
-            val outcome = runSpan.use {
-                runOnce(sagaRun).also { outcome ->
-                    if (outcome is Ended) {
-                        runSpan.setAttribute(SAGA_TERMINAL, outcome.terminal::class.simpleName ?: UNKNOWN_TERMINAL)
-                    }
-                }
-            }
+            val outcome = startSagaRunSpan(sagaRun, attempt).use { runOnce(sagaRun) }
             when (outcome) {
-                is Ended -> return outcome.terminal
+                is Ended -> {
+                    return outcome.terminal
+                }
                 is Restart -> {
                     val backoff = restartAfter(attempt, outcome.cause) ?: throw outcome.cause
                     sagaExecutionContext.recordRestart(name)
@@ -95,7 +90,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private suspend fun runOnce(sagaRun: SagaRun<PRINCIPAL, PARAMS>): SagaOutcome<TS> {
         val startedAt = System.nanoTime()
         var step = try {
-            sagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) }
+            startSagaInitSpan(sagaRun.sagaName).use { init(sagaRun.principal, sagaRun.params) }
         } catch (ex: Exception) {
             return failed(sagaRun, null, ex)
         }
@@ -106,7 +101,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                 is Intermediary<*> -> {
                     val stepStartedAt = System.nanoTime()
                     val nextStep = try {
-                        val resolved = sagaIntermediateSpan(current::class.simpleName).use {
+                        val resolved = startSagaIntermediateSpan(current::class.simpleName).use {
                             next(sagaRun.principal, current as IS)
                         }
                         if (resolved::class in trail) {
@@ -124,6 +119,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
                 }
 
                 is Terminal<*> -> {
+                    Span.current().setAttribute(SAGA_TERMINAL, current::class.simpleName ?: UNKNOWN_TERMINAL)
                     emit(sagaRun.sagaName, Notification.TERMINATED) {
                         it.onTerminated(sagaRun, current, elapsedSince(startedAt))
                     }
@@ -158,7 +154,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
         if (observers.isEmpty()) {
             return
         }
-        notifySpan(sagaName, notification).use {
+        startNotifySpan(sagaName, notification).use {
             notifyEach(sagaName, notify)
         }
     }
@@ -192,7 +188,7 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
     private fun elapsedSince(startedAtNanos: Long): Duration =
         Duration.ofNanos(System.nanoTime() - startedAtNanos)
 
-    private fun sagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>, attempt: Int) =
+    private fun startSagaRunSpan(sagaRun: SagaRun<PRINCIPAL, PARAMS>, attempt: Int) =
         sagaExecutionContext.otel.getEvaTracer()
             .spanBuilder(sagaRun.sagaName)
             .setAttribute(SAGA_RUN_ID, sagaRun.id.toString())
@@ -200,16 +196,16 @@ abstract class Saga<PRINCIPAL, PARAMS, IS, TS, SELF>(
             .apply { sagaRun.parentId?.let { setAttribute(SAGA_PARENT_RUN_ID, it.toString()) } }
             .startSpan()
 
-    private fun notifySpan(sagaName: String, notification: Notification) =
+    private fun startNotifySpan(sagaName: String, notification: Notification) =
         sagaExecutionContext.otel.getEvaTracer()
             .spanBuilder("$sagaName-${notification.suffix}")
             .startSpan()
 
-    private fun sagaInitSpan(sagaName: String) = sagaExecutionContext.otel.getEvaTracer()
+    private fun startSagaInitSpan(sagaName: String) = sagaExecutionContext.otel.getEvaTracer()
         .spanBuilder("$sagaName-init")
         .startSpan()
 
-    private fun sagaIntermediateSpan(stepName: String?) = sagaExecutionContext.otel.getEvaTracer()
+    private fun startSagaIntermediateSpan(stepName: String?) = sagaExecutionContext.otel.getEvaTracer()
         .spanBuilder(stepName?.let { "$it-intermediate" } ?: "SagaIntermediateStep")
         .startSpan()
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
@@ -25,11 +25,25 @@ data class SagaExecutionContext internal constructor(
         .build()
 
     internal fun recordObserverFailure(sagaName: String, outcome: ObserverOutcome) {
-        observerFailures.add(1, Attributes.of(SAGA_NAME, sagaName, OBSERVER_OUTCOME, outcome.value))
+        observerFailures.add(
+            1,
+            Attributes.of(
+                SAGA_NAME,
+                sagaName,
+                OBSERVER_OUTCOME,
+                outcome.value,
+            ),
+        )
     }
 
     internal fun recordRestart(sagaName: String) {
-        restarts.add(1, Attributes.of(SAGA_NAME, sagaName))
+        restarts.add(
+            1,
+            Attributes.of(
+                SAGA_NAME,
+                sagaName,
+            ),
+        )
     }
 }
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
@@ -1,12 +1,17 @@
 package com.razz.eva.saga
 
 import com.razz.eva.saga.OtelAttributes.OBSERVER_OUTCOME
+import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPT
+import com.razz.eva.saga.OtelAttributes.SAGA_EXCEPTION
 import com.razz.eva.saga.OtelAttributes.SAGA_NAME
+import com.razz.eva.saga.OtelAttributes.SAGA_OUTCOME
 import com.razz.eva.tracing.getEvaMeter
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
 import io.opentelemetry.api.metrics.LongCounter
 import java.time.Duration
+
+private const val COUNT = "count"
 
 data class SagaExecutionContext internal constructor(
     internal val otel: OpenTelemetry,
@@ -15,14 +20,32 @@ data class SagaExecutionContext internal constructor(
     private val observerFailures: LongCounter = otel.getEvaMeter()
         .counterBuilder(Metrics.OBSERVER_FAILURE)
         .setDescription("Saga observer invocations that failed or timed out")
-        .setUnit("count")
+        .setUnit(COUNT)
         .build()
 
     private val restarts: LongCounter = otel.getEvaMeter()
         .counterBuilder(Metrics.RESTART)
         .setDescription("Saga runs restarted from init after onException declined to map a failure")
-        .setUnit("count")
+        .setUnit(COUNT)
         .build()
+
+    private val outcomes: LongCounter = otel.getEvaMeter()
+        .counterBuilder(Metrics.OUTCOME)
+        .setDescription("Saga resumptions counted by how they ended")
+        .setUnit(COUNT)
+        .build()
+
+    internal fun recordOutcome(sagaName: String, outcome: RunOutcome) {
+        outcomes.add(
+            1,
+            Attributes.of(
+                SAGA_NAME,
+                sagaName,
+                SAGA_OUTCOME,
+                outcome.value,
+            ),
+        )
+    }
 
     internal fun recordObserverFailure(sagaName: String, outcome: ObserverOutcome) {
         observerFailures.add(
@@ -36,12 +59,16 @@ data class SagaExecutionContext internal constructor(
         )
     }
 
-    internal fun recordRestart(sagaName: String) {
+    internal fun recordRestart(sagaName: String, attempt: Int, exception: String) {
         restarts.add(
             1,
             Attributes.of(
                 SAGA_NAME,
                 sagaName,
+                SAGA_ATTEMPT,
+                attempt.toLong(),
+                SAGA_EXCEPTION,
+                exception,
             ),
         )
     }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
@@ -1,13 +1,44 @@
 package com.razz.eva.saga
 
+import com.razz.eva.saga.OtelAttributes.OBSERVER_OUTCOME
+import com.razz.eva.saga.OtelAttributes.SAGA_NAME
+import com.razz.eva.tracing.getEvaMeter
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.metrics.LongCounter
+import java.time.Duration
 
 data class SagaExecutionContext internal constructor(
     internal val otel: OpenTelemetry,
-)
+    internal val observerTimeout: Duration,
+) {
+    private val observerFailures: LongCounter = otel.getEvaMeter()
+        .counterBuilder(Metrics.OBSERVER_FAILURE)
+        .setDescription("Saga observer invocations that failed or timed out")
+        .setUnit("count")
+        .build()
+
+    private val restarts: LongCounter = otel.getEvaMeter()
+        .counterBuilder(Metrics.RESTART)
+        .setDescription("Saga runs restarted from init after onException declined to map a failure")
+        .setUnit("count")
+        .build()
+
+    internal fun recordObserverFailure(sagaName: String, outcome: ObserverOutcome) {
+        observerFailures.add(1, Attributes.of(SAGA_NAME, sagaName, OBSERVER_OUTCOME, outcome.value))
+    }
+
+    internal fun recordRestart(sagaName: String) {
+        restarts.add(1, Attributes.of(SAGA_NAME, sagaName))
+    }
+}
 
 fun sagaExecutionContext(
     otel: OpenTelemetry = OpenTelemetry.noop(),
+    observerTimeout: Duration = Duration.ofSeconds(3),
 ): SagaExecutionContext {
-    return SagaExecutionContext(otel)
+    require(observerTimeout.toMillis() > 0) {
+        "Saga observer timeout must be at least a millisecond, but was [$observerTimeout]"
+    }
+    return SagaExecutionContext(otel, observerTimeout)
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaExecutionContext.kt
@@ -4,7 +4,9 @@ import com.razz.eva.saga.OtelAttributes.OBSERVER_OUTCOME
 import com.razz.eva.saga.OtelAttributes.SAGA_ATTEMPT
 import com.razz.eva.saga.OtelAttributes.SAGA_EXCEPTION
 import com.razz.eva.saga.OtelAttributes.SAGA_NAME
+import com.razz.eva.saga.OtelAttributes.NONE
 import com.razz.eva.saga.OtelAttributes.SAGA_OUTCOME
+import com.razz.eva.saga.OtelAttributes.SAGA_TERMINAL
 import com.razz.eva.tracing.getEvaMeter
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.api.common.Attributes
@@ -35,7 +37,7 @@ data class SagaExecutionContext internal constructor(
         .setUnit(COUNT)
         .build()
 
-    internal fun recordOutcome(sagaName: String, outcome: RunOutcome) {
+    internal fun recordOutcome(sagaName: String, outcome: RunOutcome, terminal: String?) {
         outcomes.add(
             1,
             Attributes.of(
@@ -43,6 +45,8 @@ data class SagaExecutionContext internal constructor(
                 sagaName,
                 SAGA_OUTCOME,
                 outcome.value,
+                SAGA_TERMINAL,
+                terminal ?: NONE,
             ),
         )
     }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
@@ -4,37 +4,6 @@ import com.razz.eva.domain.Principal
 import com.razz.eva.saga.Saga.Step
 import com.razz.eva.saga.Saga.Terminal
 import java.time.Duration
-import java.util.UUID
-import java.util.UUID.randomUUID
-
-internal sealed interface SagaOutcome<out TERMINAL> {
-
-    class Ended<TERMINAL>(val terminal: TERMINAL) : SagaOutcome<TERMINAL>
-
-    class Restart(val backoff: Duration) : SagaOutcome<Nothing>
-}
-
-@JvmInline
-value class SagaRunId(private val id: UUID) {
-    override fun toString() = id.toString()
-    fun uuidValue() = id
-
-    companion object {
-        fun random() = SagaRunId(randomUUID())
-    }
-}
-
-data class SagaRun<PRINCIPAL, PARAMS>(
-    val id: SagaRunId,
-    val parentId: SagaRunId?,
-    val attempt: Int,
-    val sagaName: String,
-    val principal: PRINCIPAL,
-    val params: PARAMS,
-) where PRINCIPAL : Principal<*> {
-
-    override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId, attempt=$attempt]"
-}
 
 sealed interface SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
 

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
@@ -35,27 +35,47 @@ data class SagaRun<PRINCIPAL, PARAMS>(
     override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId]"
 }
 
+sealed interface SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+
+    val run: SagaRun<PRINCIPAL, PARAMS>
+
+    val suffix: String
+
+    class Resumed<PRINCIPAL, PARAMS>(
+        override val run: SagaRun<PRINCIPAL, PARAMS>,
+        val first: Step<*>,
+    ) : SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+        override val suffix = "onResumed"
+    }
+
+    class Transitioned<PRINCIPAL, PARAMS>(
+        override val run: SagaRun<PRINCIPAL, PARAMS>,
+        val from: Step<*>,
+        val to: Step<*>,
+        val elapsed: Duration,
+    ) : SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+        override val suffix = "onTransition"
+    }
+
+    class Terminated<PRINCIPAL, PARAMS>(
+        override val run: SagaRun<PRINCIPAL, PARAMS>,
+        val terminal: Terminal<*>,
+        val elapsed: Duration,
+    ) : SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+        override val suffix = "onTerminated"
+    }
+
+    class Failed<PRINCIPAL, PARAMS>(
+        override val run: SagaRun<PRINCIPAL, PARAMS>,
+        val step: Step<*>?,
+        val ex: Exception,
+        val mappedTo: Terminal<*>?,
+    ) : SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+        override val suffix = "onFailed"
+    }
+}
+
 interface SagaObserver<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
 
-    suspend fun onResumed(run: SagaRun<PRINCIPAL, PARAMS>, first: Step<*>)
-
-    suspend fun onTransition(
-        run: SagaRun<PRINCIPAL, PARAMS>,
-        from: Step<*>,
-        to: Step<*>,
-        elapsed: Duration,
-    )
-
-    suspend fun onTerminated(
-        run: SagaRun<PRINCIPAL, PARAMS>,
-        terminal: Terminal<*>,
-        elapsed: Duration,
-    )
-
-    suspend fun onFailed(
-        run: SagaRun<PRINCIPAL, PARAMS>,
-        step: Step<*>?,
-        ex: Exception,
-        mappedTo: Terminal<*>?,
-    )
+    suspend fun onNotification(notification: SagaNotification<PRINCIPAL, PARAMS>)
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
@@ -27,12 +27,13 @@ value class SagaRunId(private val id: UUID) {
 data class SagaRun<PRINCIPAL, PARAMS>(
     val id: SagaRunId,
     val parentId: SagaRunId?,
+    val attempt: Int,
     val sagaName: String,
     val principal: PRINCIPAL,
     val params: PARAMS,
 ) where PRINCIPAL : Principal<*> {
 
-    override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId]"
+    override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId, attempt=$attempt]"
 }
 
 sealed interface SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
@@ -11,7 +11,7 @@ internal sealed interface SagaOutcome<out TERMINAL> {
 
     class Ended<TERMINAL>(val terminal: TERMINAL) : SagaOutcome<TERMINAL>
 
-    class Restart(val cause: Exception) : SagaOutcome<Nothing>
+    class Restart(val backoff: Duration) : SagaOutcome<Nothing>
 }
 
 @JvmInline
@@ -71,6 +71,8 @@ sealed interface SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal
         val step: Step<*>?,
         val ex: Exception,
         val mappedTo: Terminal<*>?,
+        val willRestart: Boolean,
+        val elapsed: Duration,
     ) : SagaNotification<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
         override val suffix = "onFailed"
     }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaObserver.kt
@@ -1,0 +1,61 @@
+package com.razz.eva.saga
+
+import com.razz.eva.domain.Principal
+import com.razz.eva.saga.Saga.Step
+import com.razz.eva.saga.Saga.Terminal
+import java.time.Duration
+import java.util.UUID
+import java.util.UUID.randomUUID
+
+internal sealed interface SagaOutcome<out TERMINAL> {
+
+    class Ended<TERMINAL>(val terminal: TERMINAL) : SagaOutcome<TERMINAL>
+
+    class Restart(val cause: Exception) : SagaOutcome<Nothing>
+}
+
+@JvmInline
+value class SagaRunId(private val id: UUID) {
+    override fun toString() = id.toString()
+    fun uuidValue() = id
+
+    companion object {
+        fun random() = SagaRunId(randomUUID())
+    }
+}
+
+data class SagaRun<PRINCIPAL, PARAMS>(
+    val id: SagaRunId,
+    val parentId: SagaRunId?,
+    val sagaName: String,
+    val principal: PRINCIPAL,
+    val params: PARAMS,
+) where PRINCIPAL : Principal<*> {
+
+    override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId]"
+}
+
+interface SagaObserver<PRINCIPAL, PARAMS> where PRINCIPAL : Principal<*> {
+
+    suspend fun onResumed(run: SagaRun<PRINCIPAL, PARAMS>, first: Step<*>)
+
+    suspend fun onTransition(
+        run: SagaRun<PRINCIPAL, PARAMS>,
+        from: Step<*>,
+        to: Step<*>,
+        elapsed: Duration,
+    )
+
+    suspend fun onTerminated(
+        run: SagaRun<PRINCIPAL, PARAMS>,
+        terminal: Terminal<*>,
+        elapsed: Duration,
+    )
+
+    suspend fun onFailed(
+        run: SagaRun<PRINCIPAL, PARAMS>,
+        step: Step<*>?,
+        ex: Exception,
+        mappedTo: Terminal<*>?,
+    )
+}

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaRun.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/SagaRun.kt
@@ -1,0 +1,27 @@
+package com.razz.eva.saga
+
+import com.razz.eva.domain.Principal
+import java.util.UUID
+import java.util.UUID.randomUUID
+
+@JvmInline
+value class SagaRunId(private val id: UUID) {
+    override fun toString() = id.toString()
+    fun uuidValue() = id
+
+    companion object {
+        fun random() = SagaRunId(randomUUID())
+    }
+}
+
+data class SagaRun<PRINCIPAL, PARAMS>(
+    val id: SagaRunId,
+    val parentId: SagaRunId?,
+    val attempt: Int,
+    val sagaName: String,
+    val principal: PRINCIPAL,
+    val params: PARAMS,
+) where PRINCIPAL : Principal<*> {
+
+    override fun toString() = "SagaRun[sagaName=$sagaName, id=$id, parentId=$parentId, attempt=$attempt]"
+}

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
@@ -1,0 +1,30 @@
+package com.razz.eva.saga
+
+import io.opentelemetry.api.common.AttributeKey
+
+internal object Metrics {
+    const val OBSERVER_FAILURE = "saga.observer.failure"
+    const val RESTART = "saga.restart"
+}
+
+internal enum class Notification(val suffix: String) {
+    RESUMED("onResumed"),
+    TRANSITION("onTransition"),
+    TERMINATED("onTerminated"),
+    FAILED("onFailed"),
+}
+
+internal enum class ObserverOutcome(val value: String) {
+    TIMED_OUT("timed_out"),
+    THREW("threw"),
+}
+
+internal object OtelAttributes {
+    const val UNKNOWN_TERMINAL = "Unknown"
+    val SAGA_NAME = AttributeKey.stringKey("saga.name")
+    val SAGA_TERMINAL = AttributeKey.stringKey("saga.terminal")
+    val SAGA_RUN_ID = AttributeKey.stringKey("saga.run_id")
+    val SAGA_PARENT_RUN_ID = AttributeKey.stringKey("saga.parent_run_id")
+    val SAGA_ATTEMPT = AttributeKey.longKey("saga.attempt")
+    val OBSERVER_OUTCOME = AttributeKey.stringKey("saga.observer.outcome")
+}

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
@@ -26,6 +26,7 @@ internal enum class ObserverOutcome(val value: String) {
 
 internal object OtelAttributes {
     const val UNKNOWN = "Unknown"
+    const val NONE = "none"
     val SAGA_NAME = AttributeKey.stringKey("saga.name")
     val SAGA_TERMINAL = AttributeKey.stringKey("saga.terminal")
     val SAGA_RUN_ID = AttributeKey.stringKey("saga.run_id")

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
@@ -5,10 +5,18 @@ import io.opentelemetry.api.common.AttributeKey
 internal object Metrics {
     const val OBSERVER_FAILURE = "saga.observer.failure"
     const val RESTART = "saga.restart"
+    const val OUTCOME = "saga.outcome"
 }
 
 internal object Events {
     const val RESTART = "saga.restart"
+}
+
+internal enum class RunOutcome(val value: String) {
+    TERMINAL("terminal"),
+    MAPPED("mapped"),
+    RETHREW("rethrew"),
+    GAVE_UP("gave_up"),
 }
 
 internal enum class ObserverOutcome(val value: String) {
@@ -17,12 +25,14 @@ internal enum class ObserverOutcome(val value: String) {
 }
 
 internal object OtelAttributes {
-    const val UNKNOWN_TERMINAL = "Unknown"
+    const val UNKNOWN = "Unknown"
     val SAGA_NAME = AttributeKey.stringKey("saga.name")
     val SAGA_TERMINAL = AttributeKey.stringKey("saga.terminal")
     val SAGA_RUN_ID = AttributeKey.stringKey("saga.run_id")
     val SAGA_PARENT_RUN_ID = AttributeKey.stringKey("saga.parent_run_id")
     val SAGA_ATTEMPT = AttributeKey.longKey("saga.attempt")
     val SAGA_ATTEMPTS = AttributeKey.longKey("saga.attempts")
+    val SAGA_OUTCOME = AttributeKey.stringKey("saga.outcome")
+    val SAGA_EXCEPTION = AttributeKey.stringKey("saga.exception")
     val OBSERVER_OUTCOME = AttributeKey.stringKey("saga.observer.outcome")
 }

--- a/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
+++ b/eva-saga/src/main/kotlin/com/razz/eva/saga/Telemetry.kt
@@ -7,11 +7,8 @@ internal object Metrics {
     const val RESTART = "saga.restart"
 }
 
-internal enum class Notification(val suffix: String) {
-    RESUMED("onResumed"),
-    TRANSITION("onTransition"),
-    TERMINATED("onTerminated"),
-    FAILED("onFailed"),
+internal object Events {
+    const val RESTART = "saga.restart"
 }
 
 internal enum class ObserverOutcome(val value: String) {
@@ -26,5 +23,6 @@ internal object OtelAttributes {
     val SAGA_RUN_ID = AttributeKey.stringKey("saga.run_id")
     val SAGA_PARENT_RUN_ID = AttributeKey.stringKey("saga.parent_run_id")
     val SAGA_ATTEMPT = AttributeKey.longKey("saga.attempt")
+    val SAGA_ATTEMPTS = AttributeKey.longKey("saga.attempts")
     val OBSERVER_OUTCOME = AttributeKey.stringKey("saga.observer.outcome")
 }

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -89,6 +89,15 @@ internal class TwoStepObserver(private val stalls: Duration) : SagaObserver<Test
 
 private fun List<String>.endEvents() = count { it.startsWith("failed:") || it.startsWith("terminated:") }
 
+private fun InMemoryMetricReader.points(metric: String) =
+    collectAllMetrics()
+        .filter { it.name == metric }
+        .flatMap { it.longSumData.points }
+
+private fun InMemoryMetricReader.outcomes(): Map<String?, Long> =
+    points("saga.outcome")
+        .associate { it.attributes.get(AttributeKey.stringKey("saga.outcome")) to it.value }
+
 private fun InMemoryMetricReader.observerFailureSum(outcome: String? = null): Long =
     collectAllMetrics()
         .filter { it.name == "saga.observer.failure" }
@@ -517,6 +526,64 @@ internal class SagaObserverSpec : ShouldSpec({
 
         state shouldBe Finish0("it's time to stop")
         torn.applied shouldBe listOf("before")
+    }
+
+    should("count every resumption by how it ended") {
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val context = sagaExecutionContext(otel = openTelemetry)
+        val boom = IllegalStateException("can't touch this")
+
+        TestSaga(executionContext = context)
+            .resume(principal, Params({ Finish0("it's time to stop") }))
+        TestSaga(executionContext = context)
+            .resume(principal, Params({ throw boom }, { _, _, _, _ -> Finish1("swallowed") }))
+        shouldThrow<IllegalStateException> {
+            TestSaga(executionContext = context).resume(principal, Params({ throw boom }))
+        }
+        shouldThrow<IllegalStateException> {
+            TestSaga(executionContext = context, restartPolicy = { _, _ -> null })
+                .resume(principal, Params({ throw boom }, { _, _, _, _ -> null }))
+        }
+
+        metricReader.outcomes() shouldBe mapOf(
+            "terminal" to 1L,
+            "mapped" to 1L,
+            "rethrew" to 1L,
+            "gave_up" to 1L,
+        )
+    }
+
+    should("attribute a restart to its attempt and the exception that caused it") {
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when {
+                    step is Step0 -> Step1("go go go!")
+                    wasThrown -> Finish0("it's time to stop")
+                    else -> {
+                        wasThrown = true
+                        throw IllegalStateException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        TestSaga(executionContext = sagaExecutionContext(otel = openTelemetry))
+            .resume(principal, params) shouldBe Finish0("it's time to stop")
+
+        val restart = metricReader.points("saga.restart").single()
+        restart.value shouldBe 1L
+        restart.attributes.get(AttributeKey.stringKey("saga.name")) shouldBe "TestSaga"
+        restart.attributes.get(AttributeKey.longKey("saga.attempt")) shouldBe 1L
+        restart.attributes.get(AttributeKey.stringKey("saga.exception")) shouldBe "IllegalStateException"
     }
 
     should("refuse an observer timeout that is not positive") {

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -2,8 +2,10 @@ package com.razz.eva.saga
 
 import com.razz.eva.domain.Principal
 import com.razz.eva.saga.Saga.SagaHaltException
-import com.razz.eva.saga.Saga.Step
-import com.razz.eva.saga.Saga.Terminal
+import com.razz.eva.saga.SagaNotification.Failed
+import com.razz.eva.saga.SagaNotification.Resumed
+import com.razz.eva.saga.SagaNotification.Terminated
+import com.razz.eva.saga.SagaNotification.Transitioned
 import com.razz.eva.saga.TestSaga.Intermediary.Step0
 import com.razz.eva.saga.TestSaga.Intermediary.Step1
 import com.razz.eva.saga.TestSaga.Params
@@ -28,126 +30,50 @@ internal class RecordingObserver : SagaObserver<TestPrincipal, Params> {
     val parents = mutableListOf<Pair<SagaRunId, SagaRunId?>>()
     val sagaNames = mutableListOf<String>()
 
-    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) {
+    override suspend fun onNotification(notification: SagaNotification<TestPrincipal, Params>) {
+        val run = notification.run
         runIds += run.id
-        parents += run.id to run.parentId
-        sagaNames += run.sagaName
-        events += "resumed:${first::class.simpleName}"
-    }
-
-    override suspend fun onTransition(
-        run: SagaRun<TestPrincipal, Params>,
-        from: Step<*>,
-        to: Step<*>,
-        elapsed: Duration,
-    ) {
-        runIds += run.id
-        events += "transition:${from::class.simpleName}->${to::class.simpleName}"
-    }
-
-    override suspend fun onTerminated(
-        run: SagaRun<TestPrincipal, Params>,
-        terminal: Terminal<*>,
-        elapsed: Duration,
-    ) {
-        runIds += run.id
-        events += "terminated:${terminal::class.simpleName}"
-    }
-
-    override suspend fun onFailed(
-        run: SagaRun<TestPrincipal, Params>,
-        step: Step<*>?,
-        ex: Exception,
-        mappedTo: Terminal<*>?,
-    ) {
-        runIds += run.id
-        val stepName = step?.let { it::class.simpleName }
-        val mappedName = mappedTo?.let { it::class.simpleName }
-        events += "failed:$stepName:${ex::class.simpleName}:$mappedName"
+        events += when (notification) {
+            is Resumed -> {
+                parents += run.id to run.parentId
+                sagaNames += run.sagaName
+                "resumed:${notification.first::class.simpleName}"
+            }
+            is Transitioned ->
+                "transition:${notification.from::class.simpleName}->${notification.to::class.simpleName}"
+            is Terminated -> "terminated:${notification.terminal::class.simpleName}"
+            is Failed -> {
+                val stepName = notification.step?.let { it::class.simpleName }
+                val mappedName = notification.mappedTo?.let { it::class.simpleName }
+                "failed:$stepName:${notification.ex::class.simpleName}:$mappedName"
+            }
+        }
     }
 }
 
 internal class ThrowingObserver(private val failure: () -> Throwable) : SagaObserver<TestPrincipal, Params> {
 
-    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>): Unit =
+    override suspend fun onNotification(notification: SagaNotification<TestPrincipal, Params>): Unit =
         throw failure()
-
-    override suspend fun onTransition(
-        run: SagaRun<TestPrincipal, Params>,
-        from: Step<*>,
-        to: Step<*>,
-        elapsed: Duration,
-    ): Unit = throw failure()
-
-    override suspend fun onTerminated(
-        run: SagaRun<TestPrincipal, Params>,
-        terminal: Terminal<*>,
-        elapsed: Duration,
-    ): Unit = throw failure()
-
-    override suspend fun onFailed(
-        run: SagaRun<TestPrincipal, Params>,
-        step: Step<*>?,
-        ex: Exception,
-        mappedTo: Terminal<*>?,
-    ): Unit = throw failure()
 }
 
 internal class SlowObserver(private val takes: Duration) : SagaObserver<TestPrincipal, Params> {
 
-    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) =
+    override suspend fun onNotification(notification: SagaNotification<TestPrincipal, Params>) =
         delay(takes.toMillis())
-
-    override suspend fun onTransition(
-        run: SagaRun<TestPrincipal, Params>,
-        from: Step<*>,
-        to: Step<*>,
-        elapsed: Duration,
-    ) = delay(takes.toMillis())
-
-    override suspend fun onTerminated(
-        run: SagaRun<TestPrincipal, Params>,
-        terminal: Terminal<*>,
-        elapsed: Duration,
-    ) = delay(takes.toMillis())
-
-    override suspend fun onFailed(
-        run: SagaRun<TestPrincipal, Params>,
-        step: Step<*>?,
-        ex: Exception,
-        mappedTo: Terminal<*>?,
-    ) = delay(takes.toMillis())
 }
 
 internal class TwoStepObserver(private val stalls: Duration) : SagaObserver<TestPrincipal, Params> {
 
     val applied = mutableListOf<String>()
 
-    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) {
-        applied += "before"
-        delay(stalls.toMillis())
-        applied += "after"
+    override suspend fun onNotification(notification: SagaNotification<TestPrincipal, Params>) {
+        if (notification is Resumed) {
+            applied += "before"
+            delay(stalls.toMillis())
+            applied += "after"
+        }
     }
-
-    override suspend fun onTransition(
-        run: SagaRun<TestPrincipal, Params>,
-        from: Step<*>,
-        to: Step<*>,
-        elapsed: Duration,
-    ) = Unit
-
-    override suspend fun onTerminated(
-        run: SagaRun<TestPrincipal, Params>,
-        terminal: Terminal<*>,
-        elapsed: Duration,
-    ) = Unit
-
-    override suspend fun onFailed(
-        run: SagaRun<TestPrincipal, Params>,
-        step: Step<*>?,
-        ex: Exception,
-        mappedTo: Terminal<*>?,
-    ) = Unit
 }
 
 private fun List<String>.endEvents() = count { it.startsWith("failed:") || it.startsWith("terminated:") }

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -14,13 +14,19 @@ import com.razz.eva.saga.TestSaga.Terminal.Finish1
 import com.razz.eva.saga.TestSaga.TestPrincipal
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.StatusCode.ERROR
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.metrics.SdkMeterProvider
 import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
 import kotlinx.coroutines.delay
+import kotlin.coroutines.cancellation.CancellationException
 import java.time.Duration
 
 internal class RecordingObserver : SagaObserver<TestPrincipal, Params> {
@@ -199,15 +205,49 @@ internal class SagaObserverSpec : ShouldSpec({
         observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
     }
 
-    should("keep the saga on course when an observer throws an Error") {
+    should("let an Error from an observer abort the saga rather than swallow it") {
         val observer = RecordingObserver()
-        val params = Params({ Finish0("it's time to stop") })
-
+        val metricReader = InMemoryMetricReader.create()
+        val spanExporter = InMemorySpanExporter.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .setTracerProvider(
+                SdkTracerProvider.builder().addSpanProcessor(SimpleSpanProcessor.create(spanExporter)).build(),
+            )
+            .build()
         val broken = ThrowingObserver { AssertionError("observer is not implemented") }
-        val state = TestSaga(listOf(broken, observer)).resume(principal, params)
+
+        shouldThrow<AssertionError> {
+            TestSaga(
+                listOf(broken, observer),
+                sagaExecutionContext(otel = openTelemetry),
+            ).resume(principal, Params({ Finish0("it's time to stop") }))
+        }
+
+        observer.events shouldBe listOf()
+        metricReader.observerFailureSum() shouldBe 0
+        val notifySpan = spanExporter.finishedSpanItems.single { it.name == "TestSaga-onResumed" }
+        notifySpan.events.map { it.name } shouldContain "exception"
+        notifySpan.status.statusCode shouldBe ERROR
+    }
+
+    should("keep the saga on course when an observer leaks a cancellation of its own") {
+        val observer = RecordingObserver()
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val leaking = ThrowingObserver { CancellationException("the observer's own child was cancelled") }
+
+        val state = TestSaga(
+            listOf(leaking, observer),
+            sagaExecutionContext(otel = openTelemetry),
+        ).resume(principal, Params({ Finish0("it's time to stop") }))
 
         state shouldBe Finish0("it's time to stop")
         observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
+        metricReader.observerFailureSum(outcome = "threw") shouldBe 2
+        metricReader.observerFailureSum(outcome = "timed_out") shouldBe 0
     }
 
     should("record exactly one failure for a run that fails two steps deep") {

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -1,0 +1,505 @@
+package com.razz.eva.saga
+
+import com.razz.eva.domain.Principal
+import com.razz.eva.saga.Saga.SagaHaltException
+import com.razz.eva.saga.Saga.Step
+import com.razz.eva.saga.Saga.Terminal
+import com.razz.eva.saga.TestSaga.Intermediary.Step0
+import com.razz.eva.saga.TestSaga.Intermediary.Step1
+import com.razz.eva.saga.TestSaga.Params
+import com.razz.eva.saga.TestSaga.Terminal.Finish0
+import com.razz.eva.saga.TestSaga.Terminal.Finish1
+import com.razz.eva.saga.TestSaga.TestPrincipal
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.metrics.SdkMeterProvider
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader
+import kotlinx.coroutines.delay
+import java.time.Duration
+
+internal class RecordingObserver : SagaObserver<TestPrincipal, Params> {
+
+    val events = mutableListOf<String>()
+    val runIds = mutableListOf<SagaRunId>()
+    val parents = mutableListOf<Pair<SagaRunId, SagaRunId?>>()
+    val sagaNames = mutableListOf<String>()
+
+    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) {
+        runIds += run.id
+        parents += run.id to run.parentId
+        sagaNames += run.sagaName
+        events += "resumed:${first::class.simpleName}"
+    }
+
+    override suspend fun onTransition(
+        run: SagaRun<TestPrincipal, Params>,
+        from: Step<*>,
+        to: Step<*>,
+        elapsed: Duration,
+    ) {
+        runIds += run.id
+        events += "transition:${from::class.simpleName}->${to::class.simpleName}"
+    }
+
+    override suspend fun onTerminated(
+        run: SagaRun<TestPrincipal, Params>,
+        terminal: Terminal<*>,
+        elapsed: Duration,
+    ) {
+        runIds += run.id
+        events += "terminated:${terminal::class.simpleName}"
+    }
+
+    override suspend fun onFailed(
+        run: SagaRun<TestPrincipal, Params>,
+        step: Step<*>?,
+        ex: Exception,
+        mappedTo: Terminal<*>?,
+    ) {
+        runIds += run.id
+        val stepName = step?.let { it::class.simpleName }
+        val mappedName = mappedTo?.let { it::class.simpleName }
+        events += "failed:$stepName:${ex::class.simpleName}:$mappedName"
+    }
+}
+
+internal class ThrowingObserver(private val failure: () -> Throwable) : SagaObserver<TestPrincipal, Params> {
+
+    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>): Unit =
+        throw failure()
+
+    override suspend fun onTransition(
+        run: SagaRun<TestPrincipal, Params>,
+        from: Step<*>,
+        to: Step<*>,
+        elapsed: Duration,
+    ): Unit = throw failure()
+
+    override suspend fun onTerminated(
+        run: SagaRun<TestPrincipal, Params>,
+        terminal: Terminal<*>,
+        elapsed: Duration,
+    ): Unit = throw failure()
+
+    override suspend fun onFailed(
+        run: SagaRun<TestPrincipal, Params>,
+        step: Step<*>?,
+        ex: Exception,
+        mappedTo: Terminal<*>?,
+    ): Unit = throw failure()
+}
+
+internal class SlowObserver(private val takes: Duration) : SagaObserver<TestPrincipal, Params> {
+
+    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) =
+        delay(takes.toMillis())
+
+    override suspend fun onTransition(
+        run: SagaRun<TestPrincipal, Params>,
+        from: Step<*>,
+        to: Step<*>,
+        elapsed: Duration,
+    ) = delay(takes.toMillis())
+
+    override suspend fun onTerminated(
+        run: SagaRun<TestPrincipal, Params>,
+        terminal: Terminal<*>,
+        elapsed: Duration,
+    ) = delay(takes.toMillis())
+
+    override suspend fun onFailed(
+        run: SagaRun<TestPrincipal, Params>,
+        step: Step<*>?,
+        ex: Exception,
+        mappedTo: Terminal<*>?,
+    ) = delay(takes.toMillis())
+}
+
+internal class TwoStepObserver(private val stalls: Duration) : SagaObserver<TestPrincipal, Params> {
+
+    val applied = mutableListOf<String>()
+
+    override suspend fun onResumed(run: SagaRun<TestPrincipal, Params>, first: Step<*>) {
+        applied += "before"
+        delay(stalls.toMillis())
+        applied += "after"
+    }
+
+    override suspend fun onTransition(
+        run: SagaRun<TestPrincipal, Params>,
+        from: Step<*>,
+        to: Step<*>,
+        elapsed: Duration,
+    ) = Unit
+
+    override suspend fun onTerminated(
+        run: SagaRun<TestPrincipal, Params>,
+        terminal: Terminal<*>,
+        elapsed: Duration,
+    ) = Unit
+
+    override suspend fun onFailed(
+        run: SagaRun<TestPrincipal, Params>,
+        step: Step<*>?,
+        ex: Exception,
+        mappedTo: Terminal<*>?,
+    ) = Unit
+}
+
+private fun List<String>.endEvents() = count { it.startsWith("failed:") || it.startsWith("terminated:") }
+
+private fun InMemoryMetricReader.observerFailureSum(outcome: String? = null): Long =
+    collectAllMetrics()
+        .filter { it.name == "saga.observer.failure" }
+        .flatMap { metric -> metric.longSumData.points }
+        .filter { point ->
+            outcome == null || point.attributes.get(AttributeKey.stringKey("saga.observer.outcome")) == outcome
+        }
+        .sumOf { it.value }
+
+internal class SagaObserverSpec : ShouldSpec({
+
+    val principal = TestPrincipal(Principal.Id("cool-id"))
+
+    should("notify observer of resume, transition and terminal in order") {
+        val observer = RecordingObserver()
+        val params = Params({ step ->
+            when (step) {
+                is Step0 -> Step1("go go go!")
+                else -> Finish0("it's time to stop")
+            }
+        })
+
+        TestSaga(listOf(observer)).resume(principal, params)
+
+        observer.events shouldBe listOf(
+            "resumed:Step1",
+            "transition:Step1->Finish0",
+            "terminated:Finish0",
+        )
+    }
+
+    should("share one run id across every event of a run") {
+        val observer = RecordingObserver()
+        val params = Params({ Finish0("it's time to stop") })
+
+        TestSaga(listOf(observer)).resume(principal, params)
+
+        observer.runIds.distinct().size shouldBe 1
+    }
+
+    should("notify observer of failure with the terminal the exception was mapped to") {
+        val observer = RecordingObserver()
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> throw IllegalArgumentException("can't touch this")
+                }
+            },
+            { _, _, _, _ -> Finish1("swallowed") },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params)
+
+        observer.events shouldBe listOf(
+            "resumed:Step1",
+            "failed:Step1:IllegalArgumentException:Finish1",
+        )
+    }
+
+    should("end a run with exactly one failure when init threw and was mapped") {
+        val observer = RecordingObserver()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> Finish1("swallowed") },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params)
+
+        observer.events shouldBe listOf("failed:null:IllegalArgumentException:Finish1")
+    }
+
+    should("notify observer of failure before an unmapped exception propagates") {
+        val observer = RecordingObserver()
+        val params = Params({ Step0("What does the \"B\" Stand for in \"Benoit B. Mandelbrot\"?") })
+
+        shouldThrow<SagaHaltException> { TestSaga(listOf(observer)).resume(principal, params) }
+
+        observer.events shouldBe listOf(
+            "resumed:Step0",
+            "failed:Step0:SagaHaltException:null",
+        )
+    }
+
+    should("carry the previous run id as parent when onException restarts the saga") {
+        val observer = RecordingObserver()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("it's time to stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params)
+
+        val runs = observer.parents.distinct()
+        runs.size shouldBe 2
+        runs[0].second shouldBe null
+        runs[1].second shouldBe runs[0].first
+    }
+
+    should("keep the saga on course when an observer throws") {
+        val observer = RecordingObserver()
+        val params = Params({ Finish0("it's time to stop") })
+
+        val broken = ThrowingObserver { IllegalStateException("observer is broken") }
+        val state = TestSaga(listOf(broken, observer)).resume(principal, params)
+
+        state shouldBe Finish0("it's time to stop")
+        observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
+    }
+
+    should("keep the saga on course when an observer throws an Error") {
+        val observer = RecordingObserver()
+        val params = Params({ Finish0("it's time to stop") })
+
+        val broken = ThrowingObserver { AssertionError("observer is not implemented") }
+        val state = TestSaga(listOf(broken, observer)).resume(principal, params)
+
+        state shouldBe Finish0("it's time to stop")
+        observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
+    }
+
+    should("record exactly one failure for a run that fails two steps deep") {
+        val observer = RecordingObserver()
+        var call = 0
+        val params = Params({
+            when (call++) {
+                0 -> Step0("first")
+                1 -> Step1("second")
+                else -> throw IllegalArgumentException("can't touch this")
+            }
+        })
+
+        shouldThrow<IllegalArgumentException> { TestSaga(listOf(observer)).resume(principal, params) }
+
+        observer.events shouldBe listOf(
+            "resumed:Step0",
+            "transition:Step0->Step1",
+            "failed:Step1:IllegalArgumentException:null",
+        )
+    }
+
+    should("end a halted run three steps deep with exactly one failure") {
+        val observer = RecordingObserver()
+        var call = 0
+        val params = Params({
+            when (call++) {
+                0 -> Step0("first")
+                1 -> Step1("second")
+                else -> Step0("seen this one already")
+            }
+        })
+
+        shouldThrow<SagaHaltException> { TestSaga(listOf(observer)).resume(principal, params) }
+
+        observer.events.endEvents() shouldBe 1
+        observer.events shouldBe listOf(
+            "resumed:Step0",
+            "transition:Step0->Step1",
+            "failed:Step1:SagaHaltException:null",
+        )
+    }
+
+    should("end a mapped failure two steps deep with exactly one failure") {
+        val observer = RecordingObserver()
+        var call = 0
+        val params = Params(
+            {
+                when (call++) {
+                    0 -> Step0("first")
+                    1 -> Step1("second")
+                    else -> throw IllegalArgumentException("can't touch this")
+                }
+            },
+            { _, _, _, _ -> Finish1("swallowed") },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params) shouldBe Finish1("swallowed")
+
+        observer.events shouldBe listOf(
+            "resumed:Step0",
+            "transition:Step0->Step1",
+            "failed:Step1:IllegalArgumentException:Finish1",
+        )
+    }
+
+    should("count every observer invocation that threw") {
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val params = Params({ Finish0("it's time to stop") })
+
+        TestSaga(
+            listOf(ThrowingObserver { IllegalStateException("observer is broken") }),
+            sagaExecutionContext(otel = openTelemetry),
+        ).resume(principal, params)
+
+        metricReader.observerFailureSum() shouldBe 2
+    }
+
+    should("abandon an observer that outruns the timeout and carry on with the rest") {
+        val observer = RecordingObserver()
+        val metricReader = InMemoryMetricReader.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setMeterProvider(SdkMeterProvider.builder().registerMetricReader(metricReader).build())
+            .build()
+        val context = sagaExecutionContext(
+            otel = openTelemetry,
+            observerTimeout = Duration.ofMillis(20),
+        )
+
+        val startedAt = System.nanoTime()
+        val state = TestSaga(
+            listOf(SlowObserver(Duration.ofSeconds(30)), observer),
+            context,
+        ).resume(principal, Params({ Finish0("it's time to stop") }))
+        val elapsed = Duration.ofNanos(System.nanoTime() - startedAt)
+
+        state shouldBe Finish0("it's time to stop")
+        observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
+        metricReader.observerFailureSum(outcome = "timed_out") shouldBe 2
+        metricReader.observerFailureSum(outcome = "threw") shouldBe 0
+        elapsed.seconds shouldBeLessThan 5
+    }
+
+    should("bound an observer notification to three seconds unless told otherwise") {
+        sagaExecutionContext().observerTimeout shouldBe Duration.ofSeconds(3)
+    }
+
+    should("stop restarting once the policy declines and rethrow the failure that caused it") {
+        val observer = RecordingObserver()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TestSaga(
+                listOf(observer),
+                restartPolicy = { attempt, _ -> Duration.ZERO.takeIf { attempt < 2 } },
+            ).resume(principal, params)
+        }
+
+        observer.runIds.distinct().size shouldBe 3
+        val perRun = observer.runIds.zip(observer.events).groupBy({ it.first }, { it.second })
+        perRun.values.map { it.endEvents() } shouldBe listOf(1, 1, 1)
+    }
+
+    should("not restart at all when the policy declines the first attempt") {
+        val observer = RecordingObserver()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TestSaga(listOf(observer), restartPolicy = { _, _ -> null }).resume(principal, params)
+        }
+
+        observer.runIds.distinct().size shouldBe 1
+    }
+
+    should("hand the policy the attempt number and the failure that triggered the restart") {
+        val seen = mutableListOf<Pair<Int, String>>()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TestSaga(
+                restartPolicy = { attempt, ex ->
+                    seen += attempt to (ex::class.simpleName ?: "")
+                    Duration.ZERO.takeIf { attempt < 1 }
+                },
+            ).resume(principal, params)
+        }
+
+        seen shouldBe listOf(0 to "IllegalArgumentException", 1 to "IllegalArgumentException")
+    }
+
+    should("restart once by default so an existing null-returning onException keeps working") {
+        val observer = RecordingObserver()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("it's time to stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params) shouldBe Finish0("it's time to stop")
+
+        observer.runIds.distinct().size shouldBe 2
+    }
+
+    should("abandon a timed out observer mid-flight, leaving whatever it had already done in place") {
+        val torn = TwoStepObserver(Duration.ofSeconds(30))
+        val context = sagaExecutionContext(observerTimeout = Duration.ofMillis(20))
+
+        val state = TestSaga(listOf(torn), context)
+            .resume(principal, Params({ Finish0("it's time to stop") }))
+
+        state shouldBe Finish0("it's time to stop")
+        torn.applied shouldBe listOf("before")
+    }
+
+    should("refuse an observer timeout that is not positive") {
+        shouldThrow<IllegalArgumentException> { sagaExecutionContext(observerTimeout = Duration.ZERO) }
+        shouldThrow<IllegalArgumentException> { sagaExecutionContext(observerTimeout = Duration.ofSeconds(-1)) }
+    }
+
+    should("refuse an observer timeout that rounds down to no timeout at all") {
+        shouldThrow<IllegalArgumentException> { sagaExecutionContext(observerTimeout = Duration.ofNanos(500)) }
+    }
+
+    should("report the concrete saga class as the run's name") {
+        val observer = RecordingObserver()
+
+        TestSaga(listOf(observer)).resume(principal, Params({ Finish0("stop") }))
+
+        observer.sagaNames shouldBe listOf("TestSaga")
+    }
+
+    should("let a decorating saga report the delegate's name instead of its own") {
+        val observer = RecordingObserver()
+
+        TestSaga(listOf(observer), name = "DelegateSaga").resume(principal, Params({ Finish0("stop") }))
+
+        observer.sagaNames shouldBe listOf("DelegateSaga")
+    }
+})

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -290,6 +290,28 @@ internal class SagaObserverSpec : ShouldSpec({
         observer.failureWillRestart shouldBe listOf(true)
     }
 
+    should("refuse a restart backoff that truncates to no delay") {
+        val params = Params(
+            { throw IllegalStateException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TestSaga(restartPolicy = { _, _ -> Duration.ofNanos(500_000) }).resume(principal, params)
+        }.message shouldBe "Saga restart backoff must be at least a millisecond, but was [PT0.0005S]"
+    }
+
+    should("refuse a negative restart backoff") {
+        val params = Params(
+            { throw IllegalStateException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> {
+            TestSaga(restartPolicy = { _, _ -> Duration.ofMillis(-5) }).resume(principal, params)
+        }
+    }
+
     should("tell observers when it has given up instead of retrying") {
         val observer = RecordingObserver()
         val saga = TestSaga(listOf(observer), restartPolicy = { _, _ -> null })
@@ -421,7 +443,7 @@ internal class SagaObserverSpec : ShouldSpec({
         shouldThrow<IllegalArgumentException> {
             TestSaga(
                 listOf(observer),
-                restartPolicy = { attempt, _ -> Duration.ZERO.takeIf { attempt < 2 } },
+                restartPolicy = { attempt, _ -> Duration.ofMillis(1).takeIf { attempt < 2 } },
             ).resume(principal, params)
         }
 
@@ -455,7 +477,7 @@ internal class SagaObserverSpec : ShouldSpec({
             TestSaga(
                 restartPolicy = { attempt, ex ->
                     seen += attempt to (ex::class.simpleName ?: "")
-                    Duration.ZERO.takeIf { attempt < 1 }
+                    Duration.ofMillis(1).takeIf { attempt < 1 }
                 },
             ).resume(principal, params)
         }

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -15,6 +15,7 @@ import com.razz.eva.saga.TestSaga.TestPrincipal
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.comparables.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.opentelemetry.api.common.AttributeKey
@@ -35,6 +36,8 @@ internal class RecordingObserver : SagaObserver<TestPrincipal, Params> {
     val runIds = mutableListOf<SagaRunId>()
     val parents = mutableListOf<Pair<SagaRunId, SagaRunId?>>()
     val sagaNames = mutableListOf<String>()
+    val failureElapsed = mutableListOf<Duration>()
+    val failureWillRestart = mutableListOf<Boolean>()
 
     override suspend fun onNotification(notification: SagaNotification<TestPrincipal, Params>) {
         val run = notification.run
@@ -49,6 +52,8 @@ internal class RecordingObserver : SagaObserver<TestPrincipal, Params> {
                 "transition:${notification.from::class.simpleName}->${notification.to::class.simpleName}"
             is Terminated -> "terminated:${notification.terminal::class.simpleName}"
             is Failed -> {
+                failureElapsed += notification.elapsed
+                failureWillRestart += notification.willRestart
                 val stepName = notification.step?.let { it::class.simpleName }
                 val mappedName = notification.mappedTo?.let { it::class.simpleName }
                 "failed:$stepName:${notification.ex::class.simpleName}:$mappedName"
@@ -248,6 +253,54 @@ internal class SagaObserverSpec : ShouldSpec({
         observer.events shouldBe listOf("resumed:Finish0", "terminated:Finish0")
         metricReader.observerFailureSum(outcome = "threw") shouldBe 2
         metricReader.observerFailureSum(outcome = "timed_out") shouldBe 0
+    }
+
+    should("report how long the run took when it ends in a mapped failure") {
+        val observer = RecordingObserver()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> Finish1("swallowed") },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params) shouldBe Finish1("swallowed")
+
+        observer.events shouldBe listOf("failed:null:IllegalArgumentException:Finish1")
+        observer.failureElapsed.single() shouldBeGreaterThan Duration.ZERO
+    }
+
+    should("tell observers that a failure is about to be retried") {
+        val observer = RecordingObserver()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when {
+                    step is Step0 -> Step1("go go go!")
+                    wasThrown -> Finish0("it's time to stop")
+                    else -> {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        TestSaga(listOf(observer)).resume(principal, params) shouldBe Finish0("it's time to stop")
+
+        observer.failureWillRestart shouldBe listOf(true)
+    }
+
+    should("tell observers when it has given up instead of retrying") {
+        val observer = RecordingObserver()
+        val saga = TestSaga(listOf(observer), restartPolicy = { _, _ -> null })
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> { saga.resume(principal, params) }
+
+        observer.failureWillRestart shouldBe listOf(false)
     }
 
     should("record exactly one failure for a run that fails two steps deep") {

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaObserverSpec.kt
@@ -94,9 +94,12 @@ private fun InMemoryMetricReader.points(metric: String) =
         .filter { it.name == metric }
         .flatMap { it.longSumData.points }
 
-private fun InMemoryMetricReader.outcomes(): Map<String?, Long> =
-    points("saga.outcome")
-        .associate { it.attributes.get(AttributeKey.stringKey("saga.outcome")) to it.value }
+private fun InMemoryMetricReader.outcomes(): Map<Pair<String?, String?>, Long> =
+    points("saga.outcome").associate { point ->
+        val outcome = point.attributes.get(AttributeKey.stringKey("saga.outcome"))
+        val terminal = point.attributes.get(AttributeKey.stringKey("saga.terminal"))
+        (outcome to terminal) to point.value
+    }
 
 private fun InMemoryMetricReader.observerFailureSum(outcome: String? = null): Long =
     collectAllMetrics()
@@ -549,10 +552,10 @@ internal class SagaObserverSpec : ShouldSpec({
         }
 
         metricReader.outcomes() shouldBe mapOf(
-            "terminal" to 1L,
-            "mapped" to 1L,
-            "rethrew" to 1L,
-            "gave_up" to 1L,
+            ("terminal" to "Finish0") to 1L,
+            ("mapped" to "Finish1") to 1L,
+            ("rethrew" to "none") to 1L,
+            ("gave_up" to "none") to 1L,
         )
     }
 

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
@@ -193,6 +193,6 @@ internal class SagaSpanSpec : ShouldSpec({
 
         saga.resume(principal, Params({ Finish0("stop") }))
 
-        exporter.finishedSpanItems.map { it.name } shouldContain "DelegateSaga"
+        exporter.finishedSpanItems.map { it.name } shouldBe listOf("DelegateSaga-init", "DelegateSaga")
     }
 })

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
@@ -187,6 +187,41 @@ internal class SagaSpanSpec : ShouldSpec({
         restarts.single().attributes.get(AttributeKey.longKey("saga.attempt")) shouldBe 1L
     }
 
+    should("hold the name captured at resume when the saga renames itself across a restart") {
+        val observer = RecordingObserver()
+        val exporter = InMemorySpanExporter.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                    .build(),
+            )
+            .build()
+        val saga = TestSaga(listOf(observer), sagaExecutionContext(otel = openTelemetry), "FirstName")
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when {
+                    step is Step0 -> Step1("go go go!")
+                    wasThrown -> Finish0("stop")
+                    else -> {
+                        wasThrown = true
+                        saga.rename("SecondName")
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        saga.resume(principal, params)
+
+        exporter.finishedSpanItems.filter { it.name.startsWith("SecondName") } shouldBe listOf()
+        exporter.finishedSpanItems.single { it.name == "FirstName" }
+            .attributes.get(AttributeKey.longKey("saga.attempts")) shouldBe 2L
+        observer.sagaNames shouldBe listOf("FirstName", "FirstName")
+    }
+
     should("name the run span after the delegate when the saga renames itself") {
         val (exporter, saga) = exporterAndSaga(name = "DelegateSaga")
 

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
@@ -1,0 +1,198 @@
+package com.razz.eva.saga
+
+import com.razz.eva.domain.Principal
+import com.razz.eva.saga.TestSaga.Intermediary.Step0
+import com.razz.eva.saga.TestSaga.Intermediary.Step1
+import com.razz.eva.saga.TestSaga.Params
+import com.razz.eva.saga.TestSaga.Terminal.Finish0
+import com.razz.eva.saga.TestSaga.Terminal.Finish1
+import com.razz.eva.saga.TestSaga.TestPrincipal
+import com.razz.eva.tracing.use
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.trace.StatusCode.ERROR
+import io.opentelemetry.sdk.OpenTelemetrySdk
+import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
+import io.opentelemetry.sdk.trace.SdkTracerProvider
+import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+
+internal class SagaSpanSpec : ShouldSpec({
+
+    val principal = TestPrincipal(Principal.Id("cool-id"))
+
+    fun tracedSaga(name: String? = null): Triple<InMemorySpanExporter, TestSaga, OpenTelemetrySdk> {
+        val exporter = InMemorySpanExporter.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                    .build(),
+            )
+            .build()
+        val saga = TestSaga(listOf(), sagaExecutionContext(otel = openTelemetry), name)
+        return Triple(exporter, saga, openTelemetry)
+    }
+
+    fun exporterAndSaga(name: String? = null): Pair<InMemorySpanExporter, TestSaga> {
+        val (exporter, saga, _) = tracedSaga(name)
+        return exporter to saga
+    }
+
+    should("span each notification so observer time is visible in the trace") {
+        val exporter = InMemorySpanExporter.create()
+        val openTelemetry = OpenTelemetrySdk.builder()
+            .setTracerProvider(
+                SdkTracerProvider.builder()
+                    .addSpanProcessor(SimpleSpanProcessor.create(exporter))
+                    .build(),
+            )
+            .build()
+        val saga = TestSaga(listOf(RecordingObserver()), sagaExecutionContext(otel = openTelemetry))
+
+        saga.resume(principal, Params({ Finish0("stop") }))
+
+        exporter.finishedSpanItems.map { it.name } shouldBe listOf(
+            "TestSaga-init",
+            "TestSaga-onResumed",
+            "TestSaga-onTerminated",
+            "TestSaga",
+        )
+    }
+
+    should("open a span for the run and for init, and none for the terminal it ended on") {
+        val (exporter, saga) = exporterAndSaga()
+
+        saga.resume(principal, Params({ Finish0("stop") }))
+
+        exporter.finishedSpanItems.map { it.name } shouldBe listOf("TestSaga-init", "TestSaga")
+    }
+
+    should("parent every step span under the run span") {
+        val (exporter, saga) = exporterAndSaga()
+        val params = Params({ step ->
+            when (step) {
+                is Step0 -> Step1("go go go!")
+                else -> Finish0("stop")
+            }
+        })
+
+        saga.resume(principal, params)
+
+        val spans = exporter.finishedSpanItems
+        val run = spans.single { it.name == "TestSaga" }
+        val children = spans.filter { it.name != "TestSaga" }
+        children.map { it.parentSpanId }.distinct() shouldBe listOf(run.spanId)
+    }
+
+    should("record the failure on the run span") {
+        val (exporter, saga) = exporterAndSaga()
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> Finish1("swallowed") },
+        )
+
+        saga.resume(principal, params)
+
+        val run = exporter.finishedSpanItems.single { it.name == "TestSaga" }
+        run.status.statusCode shouldBe ERROR
+        run.events.map { it.name } shouldContain "exception"
+    }
+
+    should("record the terminal the run ended on as an attribute of the run span") {
+        val (exporter, saga) = exporterAndSaga()
+
+        saga.resume(principal, Params({ Finish0("stop") }))
+
+        val run = exporter.finishedSpanItems.single { it.name == "TestSaga" }
+        run.attributes.get(AttributeKey.stringKey("saga.terminal")) shouldBe "Finish0"
+    }
+
+    should("start a fresh run span for a restarted run rather than nesting it under its predecessor") {
+        val (exporter, saga) = exporterAndSaga()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        saga.resume(principal, params)
+
+        val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
+        runs.size shouldBe 2
+        runs.none { run -> runs.any { it.spanId == run.parentSpanId } } shouldBe true
+    }
+
+    should("keep every run span, restarts included, a child of the caller's span") {
+        val (exporter, saga, openTelemetry) = tracedSaga()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+        val caller = openTelemetry.getTracer("test").spanBuilder("caller").startSpan()
+
+        caller.use { saga.resume(principal, params) }
+
+        val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
+        runs.size shouldBe 2
+        runs.map { it.parentSpanId }.distinct() shouldBe listOf(caller.spanContext.spanId)
+    }
+
+    should("carry the run id on every run span and the parent run id on a restart") {
+        val (exporter, saga) = exporterAndSaga()
+        var wasThrown = false
+        val params = Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
+
+        saga.resume(principal, params)
+
+        val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
+        val runIds = runs.map { it.attributes.get(AttributeKey.stringKey("saga.run_id")) }
+        runIds.filterNotNull().size shouldBe 2
+        runs[0].attributes.get(AttributeKey.stringKey("saga.parent_run_id")) shouldBe null
+        runs[1].attributes.get(AttributeKey.stringKey("saga.parent_run_id")) shouldBe runIds[0]
+        runs.map { it.attributes.get(AttributeKey.longKey("saga.attempt")) } shouldBe listOf(0L, 1L)
+    }
+
+    should("name the run span after the delegate when the saga renames itself") {
+        val (exporter, saga) = exporterAndSaga(name = "DelegateSaga")
+
+        saga.resume(principal, Params({ Finish0("stop") }))
+
+        exporter.finishedSpanItems.map { it.name } shouldContain "DelegateSaga"
+    }
+})

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpanSpec.kt
@@ -8,21 +8,28 @@ import com.razz.eva.saga.TestSaga.Terminal.Finish0
 import com.razz.eva.saga.TestSaga.Terminal.Finish1
 import com.razz.eva.saga.TestSaga.TestPrincipal
 import com.razz.eva.tracing.use
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import io.opentelemetry.api.common.AttributeKey
 import io.opentelemetry.api.trace.StatusCode.ERROR
+import io.opentelemetry.api.trace.StatusCode.UNSET
 import io.opentelemetry.sdk.OpenTelemetrySdk
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SimpleSpanProcessor
+import java.time.Duration
 
 internal class SagaSpanSpec : ShouldSpec({
 
     val principal = TestPrincipal(Principal.Id("cool-id"))
 
-    fun tracedSaga(name: String? = null): Triple<InMemorySpanExporter, TestSaga, OpenTelemetrySdk> {
+    fun tracedSaga(
+        name: String? = null,
+        restartPolicy: ((Int, Exception) -> Duration?)? = null,
+    ): Triple<InMemorySpanExporter, TestSaga, OpenTelemetrySdk> {
         val exporter = InMemorySpanExporter.create()
         val openTelemetry = OpenTelemetrySdk.builder()
             .setTracerProvider(
@@ -31,13 +38,31 @@ internal class SagaSpanSpec : ShouldSpec({
                     .build(),
             )
             .build()
-        val saga = TestSaga(listOf(), sagaExecutionContext(otel = openTelemetry), name)
+        val saga = TestSaga(listOf(), sagaExecutionContext(otel = openTelemetry), name, restartPolicy)
         return Triple(exporter, saga, openTelemetry)
     }
 
     fun exporterAndSaga(name: String? = null): Pair<InMemorySpanExporter, TestSaga> {
         val (exporter, saga, _) = tracedSaga(name)
         return exporter to saga
+    }
+
+    fun restartingParams(): Params {
+        var wasThrown = false
+        return Params(
+            { step ->
+                when (step) {
+                    is Step0 -> Step1("go go go!")
+                    else -> if (wasThrown) {
+                        Finish0("stop")
+                    } else {
+                        wasThrown = true
+                        throw IllegalArgumentException("can't touch this")
+                    }
+                }
+            },
+            { _, _, _, _ -> null },
+        )
     }
 
     should("span each notification so observer time is visible in the trace") {
@@ -86,7 +111,7 @@ internal class SagaSpanSpec : ShouldSpec({
         children.map { it.parentSpanId }.distinct() shouldBe listOf(run.spanId)
     }
 
-    should("record the failure on the run span") {
+    should("record a mapped failure on the run span without marking the run failed") {
         val (exporter, saga) = exporterAndSaga()
         val params = Params(
             { throw IllegalArgumentException("can't touch this") },
@@ -96,8 +121,24 @@ internal class SagaSpanSpec : ShouldSpec({
         saga.resume(principal, params)
 
         val run = exporter.finishedSpanItems.single { it.name == "TestSaga" }
+        run.events.map { it.name } shouldContain "exception"
+        run.status.statusCode shouldBe UNSET
+        run.attributes.get(AttributeKey.stringKey("saga.terminal")) shouldBe "Finish1"
+    }
+
+    should("mark the run failed when the saga gives up") {
+        val (exporter, saga, _) = tracedSaga(restartPolicy = { _, _ -> null })
+        val params = Params(
+            { throw IllegalArgumentException("can't touch this") },
+            { _, _, _, _ -> null },
+        )
+
+        shouldThrow<IllegalArgumentException> { saga.resume(principal, params) }
+
+        val run = exporter.finishedSpanItems.single { it.name == "TestSaga" }
         run.status.statusCode shouldBe ERROR
         run.events.map { it.name } shouldContain "exception"
+        run.attributes.get(AttributeKey.longKey("saga.attempts")) shouldBe 1L
     }
 
     should("record the terminal the run ended on as an attribute of the run span") {
@@ -109,83 +150,41 @@ internal class SagaSpanSpec : ShouldSpec({
         run.attributes.get(AttributeKey.stringKey("saga.terminal")) shouldBe "Finish0"
     }
 
-    should("start a fresh run span for a restarted run rather than nesting it under its predecessor") {
+    should("keep one run span for the whole resumption, restarts included") {
         val (exporter, saga) = exporterAndSaga()
-        var wasThrown = false
-        val params = Params(
-            { step ->
-                when (step) {
-                    is Step0 -> Step1("go go go!")
-                    else -> if (wasThrown) {
-                        Finish0("stop")
-                    } else {
-                        wasThrown = true
-                        throw IllegalArgumentException("can't touch this")
-                    }
-                }
-            },
-            { _, _, _, _ -> null },
-        )
 
-        saga.resume(principal, params)
+        saga.resume(principal, restartingParams())
 
         val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
-        runs.size shouldBe 2
-        runs.none { run -> runs.any { it.spanId == run.parentSpanId } } shouldBe true
+        runs.size shouldBe 1
+        runs.single().attributes.get(AttributeKey.longKey("saga.attempts")) shouldBe 2L
+        runs.single().attributes.get(AttributeKey.stringKey("saga.terminal")) shouldBe "Finish0"
     }
 
-    should("keep every run span, restarts included, a child of the caller's span") {
+    should("keep the run span a child of the caller's span") {
         val (exporter, saga, openTelemetry) = tracedSaga()
-        var wasThrown = false
-        val params = Params(
-            { step ->
-                when (step) {
-                    is Step0 -> Step1("go go go!")
-                    else -> if (wasThrown) {
-                        Finish0("stop")
-                    } else {
-                        wasThrown = true
-                        throw IllegalArgumentException("can't touch this")
-                    }
-                }
-            },
-            { _, _, _, _ -> null },
-        )
         val caller = openTelemetry.getTracer("test").spanBuilder("caller").startSpan()
 
-        caller.use { saga.resume(principal, params) }
+        caller.use { saga.resume(principal, restartingParams()) }
 
         val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
-        runs.size shouldBe 2
-        runs.map { it.parentSpanId }.distinct() shouldBe listOf(caller.spanContext.spanId)
+        runs.size shouldBe 1
+        runs.single().parentSpanId shouldBe caller.spanContext.spanId
     }
 
-    should("carry the run id on every run span and the parent run id on a restart") {
+    should("record each restart as an event chaining the new run id to its predecessor") {
         val (exporter, saga) = exporterAndSaga()
-        var wasThrown = false
-        val params = Params(
-            { step ->
-                when (step) {
-                    is Step0 -> Step1("go go go!")
-                    else -> if (wasThrown) {
-                        Finish0("stop")
-                    } else {
-                        wasThrown = true
-                        throw IllegalArgumentException("can't touch this")
-                    }
-                }
-            },
-            { _, _, _, _ -> null },
-        )
 
-        saga.resume(principal, params)
+        saga.resume(principal, restartingParams())
 
-        val runs = exporter.finishedSpanItems.filter { it.name == "TestSaga" }
-        val runIds = runs.map { it.attributes.get(AttributeKey.stringKey("saga.run_id")) }
-        runIds.filterNotNull().size shouldBe 2
-        runs[0].attributes.get(AttributeKey.stringKey("saga.parent_run_id")) shouldBe null
-        runs[1].attributes.get(AttributeKey.stringKey("saga.parent_run_id")) shouldBe runIds[0]
-        runs.map { it.attributes.get(AttributeKey.longKey("saga.attempt")) } shouldBe listOf(0L, 1L)
+        val run = exporter.finishedSpanItems.single { it.name == "TestSaga" }
+        val firstRunId = run.attributes.get(AttributeKey.stringKey("saga.run_id"))
+        firstRunId shouldNotBe null
+        val restarts = run.events.filter { it.name == "saga.restart" }
+        restarts.size shouldBe 1
+        restarts.single().attributes.get(AttributeKey.stringKey("saga.parent_run_id")) shouldBe firstRunId
+        restarts.single().attributes.get(AttributeKey.stringKey("saga.run_id")) shouldNotBe firstRunId
+        restarts.single().attributes.get(AttributeKey.longKey("saga.attempt")) shouldBe 1L
     }
 
     should("name the run span after the delegate when the saga renames itself") {

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpec.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/SagaSpec.kt
@@ -18,13 +18,13 @@ internal class SagaSpec : ShouldSpec({
 
     should("stop after resume reached terminal state") {
         val params = TestSaga.Params({ Finish0("it's time to stop") })
-        val state = TestSaga.resume(principal, params)
+        val state = TestSaga().resume(principal, params)
         state shouldBe Finish0("it's time to stop")
     }
 
     should("throw SagaHaltException on duplicate state") {
         val params = TestSaga.Params({ Step0("What does the \"B\" Stand for in \"Benoit B. Mandelbrot\"?") })
-        val attempt = suspend { TestSaga.resume(principal, params) }
+        val attempt = suspend { TestSaga().resume(principal, params) }
         shouldThrow<SagaHaltException> { attempt() }
     }
 
@@ -33,7 +33,7 @@ internal class SagaSpec : ShouldSpec({
             { throw IllegalArgumentException("can't touch this") },
             { _, _, _, _ -> Finish1("swallowed") },
         )
-        val state = TestSaga.resume(principal, params)
+        val state = TestSaga().resume(principal, params)
         state shouldBe Finish1("swallowed")
     }
 
@@ -53,7 +53,7 @@ internal class SagaSpec : ShouldSpec({
                 Finish1("swallowed")
             },
         )
-        val state = TestSaga.resume(principal, params)
+        val state = TestSaga().resume(principal, params)
         observedE.shouldBeInstanceOf<IllegalArgumentException>()
         observedE?.message shouldBe "can't touch this"
         observedPrincipal shouldBe principal
@@ -83,7 +83,7 @@ internal class SagaSpec : ShouldSpec({
                 Finish1("swallowed")
             },
         )
-        val state = TestSaga.resume(principal, params)
+        val state = TestSaga().resume(principal, params)
         observedE.shouldBeInstanceOf<IllegalArgumentException>()
         observedE?.message shouldBe "can't touch this"
         observedPrincipal shouldBe principal
@@ -109,7 +109,7 @@ internal class SagaSpec : ShouldSpec({
             },
             { _, _, _, _ -> null },
         )
-        val state = TestSaga.resume(principal, params)
+        val state = TestSaga().resume(principal, params)
         state shouldBe Finish0("it's time to stop")
     }
 })

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/TestSaga.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/TestSaga.kt
@@ -8,8 +8,22 @@ import com.razz.eva.saga.TestSaga.Intermediary.Step0
 import com.razz.eva.saga.TestSaga.Params
 import com.razz.eva.saga.TestSaga.Terminal
 import com.razz.eva.saga.TestSaga.TestPrincipal
+import java.time.Duration
 
-internal object TestSaga : Saga<TestPrincipal, Params, Intermediary, Terminal, TestSaga>() {
+internal class TestSaga(
+    observers: List<SagaObserver<TestPrincipal, Params>> = listOf(),
+    executionContext: SagaExecutionContext = sagaExecutionContext(),
+    private val name: String? = null,
+    private val restartPolicy: ((Int, Exception) -> Duration?)? = null,
+) : Saga<TestPrincipal, Params, Intermediary, Terminal, TestSaga>(executionContext, observers) {
+
+    override val sagaName: String
+        get() = name ?: super.sagaName
+
+    override suspend fun restartAfter(attempt: Int, ex: Exception): Duration? {
+        val policy = restartPolicy ?: return super.restartAfter(attempt, ex)
+        return policy(attempt, ex)
+    }
 
     data class TestPrincipal(
         override val id: Id<String>,

--- a/eva-saga/src/test/kotlin/com/razz/eva/saga/TestSaga.kt
+++ b/eva-saga/src/test/kotlin/com/razz/eva/saga/TestSaga.kt
@@ -13,12 +13,16 @@ import java.time.Duration
 internal class TestSaga(
     observers: List<SagaObserver<TestPrincipal, Params>> = listOf(),
     executionContext: SagaExecutionContext = sagaExecutionContext(),
-    private val name: String? = null,
+    private var name: String? = null,
     private val restartPolicy: ((Int, Exception) -> Duration?)? = null,
 ) : Saga<TestPrincipal, Params, Intermediary, Terminal, TestSaga>(executionContext, observers) {
 
     override val sagaName: String
         get() = name ?: super.sagaName
+
+    fun rename(to: String) {
+        name = to
+    }
 
     override suspend fun restartAfter(attempt: Int, ex: Exception): Duration? {
         val policy = restartPolicy ?: return super.restartAfter(attempt, ex)


### PR DESCRIPTION
Adds two observability-related features to sagas:

1. Broader telemetry coverage
2. Optional observers

Also, adds a way to configure the restart behaviour and fixes a potential infinite restart/recursion bug.

### Telemetry coverage

Traces will be recording each resume, transition, termination, restart, and failure.

#### Saga spans emitted to OTel

| Span name | Scope | Attributes / events | Observed example |
|---|---|---|---|
| `<sagaName>` (run span) | wraps the whole resumption, all attempts included | attr `saga.run_id` (first run only, set at creation), `saga.attempts` (rewritten each attempt), `saga.terminal` (on either terminal path); events `exception` per failure and `saga.restart` per restart; `ERROR` only if `resume` genuinely throws | `PayrunSaga` — `saga.run_id=d19ff5f9.., saga.attempts=1, saga.terminal=PayrunFinished` |
| `<sagaName>-init` | one per attempt, wraps `init` | none; `ERROR` + exception event if `init` throws | `PayrunSaga-init` |
| `<StepName>-intermediate` | one per intermediary step, wraps `next` | none; `ERROR` + exception event if `next` throws | `PayrunToBeApproved-intermediate`, `PayrunApproved-intermediate`, `PayrunStarted-intermediate` |
| `<sagaName>-onResumed` | wraps observer dispatch for `Resumed` | `ERROR` only if an observer throws an `Error` | `PayrunSaga-onResumed` |
| `<sagaName>-onTransition` | wraps observer dispatch for `Transitioned` | as above | `PayrunSaga-onTransition` |
| `<sagaName>-onTerminated` | wraps observer dispatch for `Terminated` | as above | `PayrunSaga-onTerminated` |
| `<sagaName>-onFailed` | wraps observer dispatch for `Failed` | as above | `PayrunSaga-onFailed` — one lasted `3010.2ms`, an observer capped at the 3s timeout |


#### Example happy path

```
POST /payruns/{id}/pay-with-wallet            [ 2685.8ms]
├─ PayrunSaga   run_id=d19ff5f9…  attempts=1  terminal=PayrunFinished        [  531.7ms]
│  ├─ PayrunSaga-init                         [    8.6ms]  → 1× PostgreSQL [6.9ms]
│  ├─ PayrunSaga-onResumed                    [    3.0ms]
│  ├─ PayrunToBeApproved-intermediate         [   64.9ms]
│  │  └─ ApprovePayrunUow                     [   64.1ms]
│  │     ├─ ApprovePayrunUow-perform          [   15.4ms]  → 1× PostgreSQL [7.5ms]
│  │     └─ ApprovePayrunUow-persist          [   48.4ms]  → 5× PostgreSQL [36.5ms]
│  ├─ PayrunSaga-onTransition                 [    0.4ms]
│  ├─ PayrunApproved-intermediate             [  221.4ms]
│  │  ├─ 2× PostgreSQL                        [   13.8ms]
│  │  ├─ BookInternalTransferTxnUow           [  100.0ms]
│  │  │  ├─ …-perform                         [   24.0ms]  → 2× PostgreSQL [17.8ms]
│  │  │  └─ …-persist                          [   74.5ms]  → 5× PostgreSQL [52.3ms]
│  │  └─ StartPayrunUow                       [  101.3ms]
│  │     ├─ …-perform                         [   30.7ms]  → 3× PostgreSQL [24.8ms]
│  │     └─ …-persist                          [   69.7ms]  → 7× PostgreSQL [53.5ms]
│  ├─ PayrunSaga-onTransition                 [    0.3ms]
│  ├─ PayrunStarted-intermediate              [  229.9ms]
│  │  ├─ AuthorizePayrunUow                   [  203.0ms]
│  │  │  ├─ …-perform                         [  120.5ms]  → 3× PostgreSQL [113.0ms]
│  │  │  └─ …-persist                          [   81.3ms]  → 6× PostgreSQL [68.7ms]
│  │  └─ UpdateContactsHasPaymentsUow         [   25.3ms]
│  ├─ PayrunSaga-onTransition                 [    0.3ms]
│  └─ PayrunSaga-onTerminated                 [    0.5ms]
```

#### Example failure paths

```
POST /payruns/{id}/pay-with-wallet            [ 3613.1ms] ERROR
· exception: SimulatedSagaFailure: Simulated saga failure [attempt=2]
└─ PayrunSaga   run_id=ad294d49…  attempts=3  (no terminal)   [ 3239.5ms] ERROR
   · exception: SimulatedSagaFailure [attempt=0]
   · event saga.restart(attempt=1, parent_run_id=ad294d49…, run_id=8ebce42f…)
   · exception: SimulatedSagaFailure [attempt=1]
   · event saga.restart(attempt=2, parent_run_id=8ebce42f…, run_id=474f3db6…)
   · exception: SimulatedSagaFailure [attempt=2]
   · exception: SimulatedSagaFailure [attempt=2]
   ├─ PayrunSaga-init                         [    1.4ms] ERROR   attempt 0
   ├─ PayrunSaga-onFailed                     [    6.0ms]         observer threw
   ├─ PayrunSaga-init                         [    0.3ms] ERROR   attempt 1
   ├─ PayrunSaga-onFailed                     [ 3010.2ms]         observer timed out at 3s
   ├─ PayrunSaga-init                         [    0.5ms] ERROR   attempt 2
   └─ PayrunSaga-onFailed                     [    1.2ms]         willRestart=false, gave up
```

#### Metrics

| Metric | Description | Attributes |
|---|---|---|
| `saga.outcome` | One increment per `resume` that concludes, labelled by how it ended | `saga.name`, `saga.outcome` (`terminal`/`mapped`/`rethrew`/`gave_up`), `saga.terminal` (terminal name or `none`) | 
| `saga.restart` | One increment per restart, after `onException` declined to map a failure | `saga.name`, `saga.attempt` (long), `saga.exception` (simple name or `Unknown`) |
| `saga.observer.failure` | One increment per observer that threw or overran its timeout; saga outcome unaffected | `saga.name`, `saga.observer.outcome` (`threw`/`timed_out`) |


### Observers

A list of observers can now be passed as an optional parameter to any saga, e.g.

```
class PayrunSaga(
...
) : Saga<AnyPayrunSagaPrincipal, Params, Intermediary, Terminal, PayrunSaga>(
    sagaExecutionContext = sagaExecutionContext(otel = GlobalOpenTelemetry.get()),
    observers = listOf(LoggingSagaObserver()),
)
```
Each observer implements the `SagaObserver` interface with one `onNotification` method to override.
The method is called on each observer when the saga starts, transitions, terminates, or fails.

| Notification type | Span suffix | Fired when | Extra fields | Example |
|---|---|---|---|---|
| `Resumed` | `onResumed` | `init` resolved the first step of a run | `first: Step<*>` | `first=[PayrunToBeApproved]` |
| `Transitioned` | `onTransition` | `next` resolved a following step, terminal ones included | `from: Step<*>`, `to: Step<*>`, `elapsed: Duration` | `from=[PayrunStarted] to=[PayrunFinished] took=[229ms]` |
| `Terminated` | `onTerminated` | the run reached a `Terminal` | `terminal: Terminal<*>`, `elapsed: Duration` | `terminal=[PayrunFinished] took=[531ms]` |
| `Failed` | `onFailed` | a step threw, once per attempt | `step: Step<*>?`, `ex: Exception`, `mappedTo: Terminal<*>?`, `willRestart: Boolean`, `elapsed: Duration` | `step=[null] ex=[SimulatedSagaFailure: Simulated saga failure [attempt=2]] mappedTo=[null] willRestart=[false] took=[1ms]` |

### Configurable restarts

The logic that decides whether the saga should restart after a failure that returns `null` from `onException` (the implicit signal to attempt a restart) can now be configured through overriding `Saga.restartAfter`.
The default logic is:
```
    protected open suspend fun restartAfter(attempt: Int, ex: Exception): Duration? =
        RESTART_BACKOFF.takeIf { attempt < MAX_RESTARTS }
```
where `MAX_RESTARTS = 2` and `RESTART_BACKOFF = 100ms`. The returned duration is how long the saga should wait before restarting.
Having this also makes sure we never fall into an infinite restart loop that results in a stack overflow error.

