### PR TITLE
run the uow spec verify lambda once

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
@@ -71,19 +71,31 @@ class UowSpec<R> internal constructor(
         return verified
     }
 
+    /**
+     * Verifies the next registered change as an added model, and asserts that the unit of work returned
+     * that model: same id, and the change carries every event the result carries. A unit of work that
+     * returns a model it never registered, or a mutation of one it registered, fails here -- verify the
+     * change and the result separately with `adds<M> { }` plus `returns { }` if that is really intended.
+     */
     inline fun <reified M : Model<*, *>> addsAndReturns(noinline verify: M.() -> Unit): M {
         val verified = verifyAddedModel(verify)
-        verifyResultIsModel(verified, "added")
+        verifyResultIsAddedModel(verified)
         return verified
     }
 
+    /**
+     * Verifies the next registered change as an added model, and asserts that the unit of work returned
+     * that model: same id, and the change carries every event the result carries. A unit of work that
+     * returns a model it never registered, or a mutation of one it registered, fails here -- verify the
+     * change and the result separately with `adds<M> { }` plus `returns { }` if that is really intended.
+     */
     inline fun <reified M : Model<*, *>> EqualityVerifierAware.addsAndReturns(
         id: ModelId<*>,
         noinline verify: M.() -> Unit,
     ): M {
         val verified = verifyAddedModel(verify)
         equalityVerifier.verify(verified.id(), id)
-        verifyResultIsModel(verified, "added")
+        verifyResultIsAddedModel(verified)
         return verified
     }
 
@@ -115,19 +127,31 @@ class UowSpec<R> internal constructor(
         return verified
     }
 
+    /**
+     * Verifies the next registered change as an updated model, and asserts that the unit of work returned
+     * that model: same id, and the change carries every event the result carries. A unit of work that
+     * returns a model it never registered, or a mutation of one it registered, fails here -- verify the
+     * change and the result separately with `updates<M> { }` plus `returns { }` if that is really intended.
+     */
     inline fun <reified M : Model<*, *>> updatesAndReturns(noinline verify: M.() -> Unit): M {
         val verified = verifyUpdatedModel(verify)
-        verifyResultIsModel(verified, "updated")
+        verifyResultIsUpdatedModel(verified)
         return verified
     }
 
+    /**
+     * Verifies the next registered change as an updated model, and asserts that the unit of work returned
+     * that model: same id, and the change carries every event the result carries. A unit of work that
+     * returns a model it never registered, or a mutation of one it registered, fails here -- verify the
+     * change and the result separately with `updates<M> { }` plus `returns { }` if that is really intended.
+     */
     inline fun <reified M : Model<*, *>> EqualityVerifierAware.updatesAndReturns(
         id: ModelId<*>,
         noinline verify: M.() -> Unit,
     ): M {
         val verified = verifyUpdatedModel(verify)
         equalityVerifier.verify(verified.id(), id)
-        verifyResultIsModel(verified, "updated")
+        verifyResultIsUpdatedModel(verified)
         return verified
     }
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpec.kt
@@ -72,17 +72,18 @@ class UowSpec<R> internal constructor(
     }
 
     inline fun <reified M : Model<*, *>> addsAndReturns(noinline verify: M.() -> Unit): M {
-        verifyResultAsInternal(verify)
-        return verifyAddedModel(verify)
+        val verified = verifyAddedModel(verify)
+        verifyResultIsModel(verified, "added")
+        return verified
     }
 
     inline fun <reified M : Model<*, *>> EqualityVerifierAware.addsAndReturns(
         id: ModelId<*>,
         noinline verify: M.() -> Unit,
     ): M {
-        verifyResultAsInternal(verify)
         val verified = verifyAddedModel(verify)
         equalityVerifier.verify(verified.id(), id)
+        verifyResultIsModel(verified, "added")
         return verified
     }
 
@@ -115,17 +116,18 @@ class UowSpec<R> internal constructor(
     }
 
     inline fun <reified M : Model<*, *>> updatesAndReturns(noinline verify: M.() -> Unit): M {
-        verifyResultAsInternal(verify)
-        return verifyUpdatedModel(verify)
+        val verified = verifyUpdatedModel(verify)
+        verifyResultIsModel(verified, "updated")
+        return verified
     }
 
     inline fun <reified M : Model<*, *>> EqualityVerifierAware.updatesAndReturns(
         id: ModelId<*>,
         noinline verify: M.() -> Unit,
     ): M {
-        verifyResultAsInternal(verify)
         val verified = verifyUpdatedModel(verify)
         equalityVerifier.verify(verified.id(), id)
+        verifyResultIsModel(verified, "updated")
         return verified
     }
 

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
@@ -61,6 +61,20 @@ open class UowSpecBase<R> private constructor(
         verification(result as RR)
     }
 
+    /**
+     * Asserts that the unit of work returned the very model instance it registered as a change.
+     * Identity, not equality: models override equals over their fields only, so an equal-but-stale
+     * instance (different version or unflushed events) would pass a value comparison.
+     */
+    @PublishedApi
+    internal fun verifyResultIsModel(model: Model<*, *>, changeKind: String) {
+        val actual: Any? = result
+        check(actual === model) {
+            val hint = if (actual == model) " (equal by value, but a different instance)" else ""
+            "Result is not the $changeKind model$hint. Expected [$model] but result was [$actual]"
+        }
+    }
+
     @PublishedApi
     internal fun <M : Model<*, *>> verifyAddedModel(verify: (M) -> Unit): M {
         val model = when (

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/verify/UowSpecBase.kt
@@ -46,7 +46,9 @@ open class UowSpecBase<R> private constructor(
             "No more entity changes expected, but still present: $entityChangeHistory"
         }
         check(publishedEvents.isEmpty()) {
-            "No more events expected, but still present: $publishedEvents"
+            "No more events expected, but still present: ${publishedEvents.joinToString { describeEvent(it) }}. " +
+                "Every event a change raises has to be asserted by its own emits call, so a change raising " +
+                "two events needs two of them"
         }
     }
 
@@ -62,16 +64,54 @@ open class UowSpecBase<R> private constructor(
     }
 
     /**
-     * Asserts that the unit of work returned the very model instance it registered as a change.
-     * Identity, not equality: models override equals over their fields only, so an equal-but-stale
-     * instance (different version or unflushed events) would pass a value comparison.
+     * Asserts that the unit of work result denotes the model registered as this change: same id, and the
+     * change carries every event the result carries.
+     *
+     * Not identity. [com.razz.eva.uow.UnitOfWorkExecutor] resolves a model result against the flushed set
+     * by id (`returnRoundtrippedModels` defaults to true), so the id is what the framework guarantees the
+     * caller receives. A composed parent may legitimately return the instance a child registered after
+     * merging a newer one over it, and `roundtrip { p -> p(model) }` seeds its value from the change set as
+     * of that moment, which a later merge supersedes -- both return an earlier instance of the same model,
+     * and both are correct at runtime.
+     *
+     * The event check is what an id alone cannot do: it rejects a result carrying state that was never
+     * registered, so it will not be persisted. It is the same rule the composable
+     * [com.razz.eva.uow.composable.ChangesDsl] merge applies (`isSameAs` / `isSuccessorOf`): the change's
+     * events have to hold the result's events by identity, in order, from the same start. Identity, because
+     * raising an event appends to the existing instances rather than rebuilding them, so a genuine earlier
+     * instance of the same model shares its event objects with the change.
      */
     @PublishedApi
-    internal fun verifyResultIsModel(model: Model<*, *>, changeKind: String) {
+    internal fun verifyResultIsAddedModel(change: Model<*, *>) = verifyResultIsModel(change, "added")
+
+    @PublishedApi
+    internal fun verifyResultIsUpdatedModel(change: Model<*, *>) = verifyResultIsModel(change, "updated")
+
+    private fun verifyResultIsModel(change: Model<*, *>, changeKind: String) {
         val actual: Any? = result
-        check(actual === model) {
-            val hint = if (actual == model) " (equal by value, but a different instance)" else ""
-            "Result is not the $changeKind model$hint. Expected [$model] but result was [$actual]"
+        if (actual !is Model<*, *>) {
+            error(
+                "Result is not a model at all, so it cannot be the $changeKind model " +
+                    "${describe(change)}. Result was ${render(actual)}",
+            )
+        }
+        if (actual.id() != change.id()) {
+            error(
+                "Result is not the $changeKind model: the ids differ. The change at this position is " +
+                    "${describe(change)}, the result is ${describe(actual)}. Check that the verify calls " +
+                    "are in the same order as the registered changes.",
+            )
+        }
+        val changeEvents = eventsOf(change)
+        val resultEvents = eventsOf(actual)
+        check(changeEvents carriesAtLeast resultEvents) {
+            val reason = if (resultEvents.size > changeEvents.size) {
+                "the result carries events the change does not, so they would never be persisted"
+            } else {
+                "the result carries a different history, so it is not an instance of this change"
+            }
+            "Result is not the $changeKind model [${change.id().stringValue()}]: $reason. The change holds " +
+                "${eventNames(changeEvents)}, the result holds ${eventNames(resultEvents)}"
         }
     }
 
@@ -177,5 +217,43 @@ open class UowSpecBase<R> private constructor(
         @Suppress("UNCHECKED_CAST")
         verify(key as K)
         return key
+    }
+
+    private fun describe(model: Model<*, *>): String {
+        val state = when {
+            model.isNew() -> "new"
+            model.isDirty() -> "dirty"
+            model.isPersisted() -> "persisted"
+            else -> "unknown state"
+        }
+        return "${model::class.simpleName}[id = ${model.id().stringValue()}, $state, " +
+            "version = ${model.version().version}, events = ${eventNames(eventsOf(model))}]"
+    }
+
+    private fun render(value: Any?): String = when (value) {
+        null -> "[null]"
+        else -> "[${value::class.simpleName}: $value]"
+    }
+
+    private fun eventNames(events: List<ModelEvent<*>>): String =
+        events.joinToString(prefix = "[", postfix = "]") { it.eventName() }
+
+    private fun describeEvent(event: ModelEvent<*>): String =
+        "${event.eventName()}(${event.modelName} ${event.modelId.stringValue()})"
+
+    @Suppress("UNCHECKED_CAST")
+    private fun eventsOf(model: Model<*, *>): List<ModelEvent<*>> =
+        (model as Model<ModelId<out Comparable<*>>, ModelEvent<ModelId<out Comparable<*>>>>).modelEvents()
+
+    private infix fun List<ModelEvent<*>>.carriesAtLeast(events: List<ModelEvent<*>>): Boolean {
+        if (size < events.size) {
+            return false
+        }
+        events.forEachIndexed { i, e ->
+            if (this[i] !== e) {
+                return false
+            }
+        }
+        return true
     }
 }

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/verify/UowSpecVerifySpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/verify/UowSpecVerifySpec.kt
@@ -1,0 +1,213 @@
+package com.razz.eva.uow.verify
+
+import com.razz.eva.domain.Department.OwnedDepartment
+import com.razz.eva.domain.DepartmentId.Companion.randomDepartmentId
+import com.razz.eva.domain.Employee
+import com.razz.eva.domain.EmployeeEvent.DepartmentChanged
+import com.razz.eva.domain.EmployeeEvent.EmployeeCreated
+import com.razz.eva.domain.EmployeeId
+import com.razz.eva.domain.ModelState.NewState.Companion.newState
+import com.razz.eva.domain.Name
+import com.razz.eva.domain.Ration.BUBALEH
+import com.razz.eva.test.domain.persistentStateV1
+import com.razz.eva.test.uow.UowBehaviorSpec
+import com.razz.eva.uow.ChangesAccumulator
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import java.util.UUID.randomUUID
+
+class UowSpecVerifySpec : UowBehaviorSpec({
+
+    val name = Name("Ivan", "Ivanov")
+    val oldDepId = randomDepartmentId()
+    val newDepId = randomDepartmentId()
+    val newDep = OwnedDepartment(
+        newDepId, "new and cool", EmployeeId(randomUUID()), 1, BUBALEH,
+        persistentStateV1(),
+    )
+
+    fun newEmployee(id: EmployeeId) = Employee(
+        id = id,
+        name = name,
+        departmentId = oldDepId,
+        email = "ivan.ivanov@lame.dep",
+        ration = BUBALEH,
+        modelState = newState(EmployeeCreated(id, name, oldDepId, "ivan.ivanov@lame.dep", BUBALEH)),
+    )
+
+    fun existingEmployee(id: EmployeeId) = Employee(
+        id = id,
+        name = name,
+        departmentId = oldDepId,
+        email = "ivan.ivanov@lame.dep",
+        ration = BUBALEH,
+        modelState = persistentStateV1(),
+    )
+
+    Given("Changes adding a model and returning the very same instance") {
+        val employeeId = EmployeeId(randomUUID())
+        val employee = newEmployee(employeeId)
+        val changes = ChangesAccumulator().withAddedModel(employee).withResult(employee)
+
+        When("addsAndReturns verifies with a block that counts its own invocations") {
+            var invocations = 0
+
+            changes verifyInOrder {
+                addsAndReturns<Employee> { invocations++ }
+                emits<EmployeeCreated> { }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+
+        When("addsAndReturns verifies with a block that nests emits") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<Employee> {
+                        departmentId shouldBe oldDepId
+                        emits<EmployeeCreated> {
+                            employeeId shouldBe employee.id()
+                        }
+                    }
+                }
+            }
+
+            Then("Nested emits consumes the single event and the spec ends clean") {
+                verifying()
+            }
+        }
+
+        When("addsAndReturns verifies with a block that does not hold") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<Employee> { departmentId shouldBe newDepId }
+                    emits<EmployeeCreated> { }
+                }
+            }
+
+            Then("The block failure surfaces") {
+                shouldThrow<AssertionError>(verifying)
+            }
+        }
+
+        When("addsAndReturns is given an id via the equality verifier") {
+            var invocations = 0
+
+            changes verifyInOrder {
+                addsAndReturns<Employee>(employeeId) { invocations++ }
+                emits<EmployeeCreated> { }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+
+        When("addsAndReturns is given an id that does not match") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<Employee>(EmployeeId(randomUUID())) { }
+                    emits<EmployeeCreated> { }
+                }
+            }
+
+            Then("The id mismatch surfaces") {
+                shouldThrow<AssertionError>(verifying)
+            }
+        }
+    }
+
+    Given("Changes adding a model and returning an equal but different instance") {
+        val employeeId = EmployeeId(randomUUID())
+        val added = newEmployee(employeeId)
+        val twin = newEmployee(employeeId)
+        val changes = ChangesAccumulator().withAddedModel(added).withResult(twin)
+
+        When("addsAndReturns verifies the added model") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<Employee> { }
+                    emits<EmployeeCreated> { }
+                }
+            }
+
+            Then("The result is reported as not being the added model") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "Result is not the added model"
+                exception.message shouldContain "equal by value, but a different instance"
+            }
+        }
+    }
+
+    Given("Changes updating a model and returning the very same instance") {
+        val employeeId = EmployeeId(randomUUID())
+        val employee = existingEmployee(employeeId).changeDepartment(newDep)
+        val changes = ChangesAccumulator().withUpdatedModel(employee).withResult(employee)
+
+        When("updatesAndReturns verifies with a block that counts its own invocations") {
+            var invocations = 0
+
+            changes verifyInOrder {
+                updatesAndReturns<Employee> { invocations++ }
+                emits<DepartmentChanged> { }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+
+        When("updatesAndReturns verifies with a block that nests emits") {
+            val verifying = {
+                changes verifyInOrder {
+                    updatesAndReturns<Employee> {
+                        departmentId shouldBe newDepId
+                        emits<DepartmentChanged> {
+                            newDepartmentId shouldBe newDepId
+                        }
+                    }
+                }
+            }
+
+            Then("Nested emits consumes the single event and the spec ends clean") {
+                verifying()
+            }
+        }
+
+        When("updatesAndReturns is given an id via the equality verifier") {
+            var invocations = 0
+
+            changes verifyInOrder {
+                updatesAndReturns<Employee>(employeeId) { invocations++ }
+                emits<DepartmentChanged> { }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+    }
+
+    Given("Changes updating a model and returning an unrelated value") {
+        val employeeId = EmployeeId(randomUUID())
+        val employee = existingEmployee(employeeId).changeDepartment(newDep)
+        val changes = ChangesAccumulator().withUpdatedModel(employee).withResult(employeeId)
+
+        When("updatesAndReturns verifies the updated model") {
+            val verifying = {
+                changes verifyInOrder {
+                    updatesAndReturns<Employee> { }
+                    emits<DepartmentChanged> { }
+                }
+            }
+
+            Then("The result is reported as not being the updated model") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "Result is not the updated model"
+            }
+        }
+    }
+})

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/verify/UowSpecVerifySpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/verify/UowSpecVerifySpec.kt
@@ -1,61 +1,46 @@
 package com.razz.eva.uow.verify
 
-import com.razz.eva.domain.Department.OwnedDepartment
-import com.razz.eva.domain.DepartmentId.Companion.randomDepartmentId
-import com.razz.eva.domain.Employee
-import com.razz.eva.domain.EmployeeEvent.DepartmentChanged
-import com.razz.eva.domain.EmployeeEvent.EmployeeCreated
-import com.razz.eva.domain.EmployeeId
-import com.razz.eva.domain.ModelState.NewState.Companion.newState
-import com.razz.eva.domain.Name
-import com.razz.eva.domain.Ration.BUBALEH
-import com.razz.eva.test.domain.persistentStateV1
-import com.razz.eva.test.uow.UowBehaviorSpec
+import com.razz.eva.domain.TestModel
+import com.razz.eva.domain.TestModel.Factory.createdTestModel
+import com.razz.eva.domain.TestModel.Factory.existingCreatedTestModel
+import com.razz.eva.domain.TestModelEvent.TestModelCreated
+import com.razz.eva.domain.TestModelEvent.TestModelStatusChanged
+import com.razz.eva.domain.TestModelId.Companion.randomTestModelId
+import com.razz.eva.domain.Version.Companion.V1
 import com.razz.eva.uow.ChangesAccumulator
+import com.razz.eva.uow.Clocks.fixedUTC
+import com.razz.eva.uow.Clocks.millisUTC
+import com.razz.eva.uow.ExecutionContext
+import com.razz.eva.uow.TestPrincipal
+import com.razz.eva.uow.composable.DummyUow
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
-import java.util.UUID.randomUUID
+import io.opentelemetry.api.OpenTelemetry
+import com.razz.eva.uow.composable.UnitOfWork as ComposableUnitOfWork
 
-class UowSpecVerifySpec : UowBehaviorSpec({
+class UowSpecVerifySpec : BehaviorSpec({
 
-    val name = Name("Ivan", "Ivanov")
-    val oldDepId = randomDepartmentId()
-    val newDepId = randomDepartmentId()
-    val newDep = OwnedDepartment(
-        newDepId, "new and cool", EmployeeId(randomUUID()), 1, BUBALEH,
-        persistentStateV1(),
-    )
+    val executionContext = ExecutionContext(fixedUTC(millisUTC().instant()), OpenTelemetry.noop())
 
-    fun newEmployee(id: EmployeeId) = Employee(
-        id = id,
-        name = name,
-        departmentId = oldDepId,
-        email = "ivan.ivanov@lame.dep",
-        ration = BUBALEH,
-        modelState = newState(EmployeeCreated(id, name, oldDepId, "ivan.ivanov@lame.dep", BUBALEH)),
-    )
+    val equalityAware = object : EqualityVerifierAware {
+        override val equalityVerifier = object : EqualityVerifier {
+            override fun <T> verify(expected: T, actual: T) {
+                expected shouldBe actual
+            }
+        }
+    }
 
-    fun existingEmployee(id: EmployeeId) = Employee(
-        id = id,
-        name = name,
-        departmentId = oldDepId,
-        email = "ivan.ivanov@lame.dep",
-        ration = BUBALEH,
-        modelState = persistentStateV1(),
-    )
-
-    Given("Changes adding a model and returning the very same instance") {
-        val employeeId = EmployeeId(randomUUID())
-        val employee = newEmployee(employeeId)
-        val changes = ChangesAccumulator().withAddedModel(employee).withResult(employee)
+    Given("A change adding a new model, returned by the unit of work") {
+        val added = createdTestModel("MLG", 420)
+        val changes = ChangesAccumulator().withAddedModel(added).withResult(added)
 
         When("addsAndReturns verifies with a block that counts its own invocations") {
             var invocations = 0
-
             changes verifyInOrder {
-                addsAndReturns<Employee> { invocations++ }
-                emits<EmployeeCreated> { }
+                addsAndReturns<TestModel> { invocations++ }
+                emits<TestModelCreated> { }
             }
 
             Then("The block ran exactly once") {
@@ -63,28 +48,41 @@ class UowSpecVerifySpec : UowBehaviorSpec({
             }
         }
 
-        When("addsAndReturns verifies with a block that nests emits") {
+        When("addsAndReturns is given an id and a block that counts its own invocations") {
+            var invocations = 0
+            with(equalityAware) {
+                changes verifyInOrder {
+                    addsAndReturns<TestModel>(added.id()) { invocations++ }
+                    emits<TestModelCreated> { }
+                }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+
+        When("The verify block nests emits and the change raises a single event") {
             val verifying = {
                 changes verifyInOrder {
-                    addsAndReturns<Employee> {
-                        departmentId shouldBe oldDepId
-                        emits<EmployeeCreated> {
-                            employeeId shouldBe employee.id()
+                    addsAndReturns<TestModel> {
+                        emits<TestModelCreated> {
+                            testModelId shouldBe added.id()
                         }
                     }
                 }
             }
 
-            Then("Nested emits consumes the single event and the spec ends clean") {
+            Then("Nested emits consumes the event and the spec ends clean") {
                 verifying()
             }
         }
 
-        When("addsAndReturns verifies with a block that does not hold") {
+        When("The verify block does not hold") {
             val verifying = {
                 changes verifyInOrder {
-                    addsAndReturns<Employee> { departmentId shouldBe newDepId }
-                    emits<EmployeeCreated> { }
+                    addsAndReturns<TestModel> { status() shouldBe null }
+                    emits<TestModelCreated> { }
                 }
             }
 
@@ -93,24 +91,13 @@ class UowSpecVerifySpec : UowBehaviorSpec({
             }
         }
 
-        When("addsAndReturns is given an id via the equality verifier") {
-            var invocations = 0
-
-            changes verifyInOrder {
-                addsAndReturns<Employee>(employeeId) { invocations++ }
-                emits<EmployeeCreated> { }
-            }
-
-            Then("The block ran exactly once") {
-                invocations shouldBe 1
-            }
-        }
-
         When("addsAndReturns is given an id that does not match") {
             val verifying = {
-                changes verifyInOrder {
-                    addsAndReturns<Employee>(EmployeeId(randomUUID())) { }
-                    emits<EmployeeCreated> { }
+                with(equalityAware) {
+                    changes verifyInOrder {
+                        addsAndReturns<TestModel>(randomTestModelId()) { }
+                        emits<TestModelCreated> { }
+                    }
                 }
             }
 
@@ -120,39 +107,50 @@ class UowSpecVerifySpec : UowBehaviorSpec({
         }
     }
 
-    Given("Changes adding a model and returning an equal but different instance") {
-        val employeeId = EmployeeId(randomUUID())
-        val added = newEmployee(employeeId)
-        val twin = newEmployee(employeeId)
-        val changes = ChangesAccumulator().withAddedModel(added).withResult(twin)
+    Given("A change raising two events, verified with a single nested emits") {
+        val added = createdTestModel("MLG", 420).activate()
+        val changes = ChangesAccumulator().withAddedModel(added).withResult(added)
 
-        When("addsAndReturns verifies the added model") {
+        When("The verify block asserts only the first of the two events") {
             val verifying = {
                 changes verifyInOrder {
-                    addsAndReturns<Employee> { }
-                    emits<EmployeeCreated> { }
+                    addsAndReturns<TestModel> { emits<TestModelCreated> { } }
                 }
             }
 
-            Then("The result is reported as not being the added model") {
+            Then("The unasserted event is reported, naming it and the one-emits-per-event rule") {
                 val exception = shouldThrow<IllegalStateException>(verifying)
-                exception.message shouldContain "Result is not the added model"
-                exception.message shouldContain "equal by value, but a different instance"
+                exception.message shouldContain "No more events expected"
+                exception.message shouldContain "TestModelStatusChanged"
+                exception.message shouldContain "its own emits call"
+            }
+        }
+
+        When("The verify block asserts both events") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> {
+                        emits<TestModelCreated> { }
+                        emits<TestModelStatusChanged> { }
+                    }
+                }
+            }
+
+            Then("The spec ends clean") {
+                verifying()
             }
         }
     }
 
-    Given("Changes updating a model and returning the very same instance") {
-        val employeeId = EmployeeId(randomUUID())
-        val employee = existingEmployee(employeeId).changeDepartment(newDep)
-        val changes = ChangesAccumulator().withUpdatedModel(employee).withResult(employee)
+    Given("A change updating a model, returned by the unit of work") {
+        val updated = existingCreatedTestModel(randomTestModelId(), "noscope", 360, V1).activate()
+        val changes = ChangesAccumulator().withUpdatedModel(updated).withResult(updated)
 
         When("updatesAndReturns verifies with a block that counts its own invocations") {
             var invocations = 0
-
             changes verifyInOrder {
-                updatesAndReturns<Employee> { invocations++ }
-                emits<DepartmentChanged> { }
+                updatesAndReturns<TestModel> { invocations++ }
+                emits<TestModelStatusChanged> { }
             }
 
             Then("The block ran exactly once") {
@@ -160,53 +158,260 @@ class UowSpecVerifySpec : UowBehaviorSpec({
             }
         }
 
-        When("updatesAndReturns verifies with a block that nests emits") {
+        When("updatesAndReturns is given an id and a block that counts its own invocations") {
+            var invocations = 0
+            with(equalityAware) {
+                changes verifyInOrder {
+                    updatesAndReturns<TestModel>(updated.id()) { invocations++ }
+                    emits<TestModelStatusChanged> { }
+                }
+            }
+
+            Then("The block ran exactly once") {
+                invocations shouldBe 1
+            }
+        }
+
+        When("The verify block nests emits and the change raises a single event") {
             val verifying = {
                 changes verifyInOrder {
-                    updatesAndReturns<Employee> {
-                        departmentId shouldBe newDepId
-                        emits<DepartmentChanged> {
-                            newDepartmentId shouldBe newDepId
+                    updatesAndReturns<TestModel> {
+                        emits<TestModelStatusChanged> {
+                            testModelId shouldBe updated.id()
                         }
                     }
                 }
             }
 
-            Then("Nested emits consumes the single event and the spec ends clean") {
+            Then("Nested emits consumes the event and the spec ends clean") {
                 verifying()
             }
         }
 
-        When("updatesAndReturns is given an id via the equality verifier") {
-            var invocations = 0
-
-            changes verifyInOrder {
-                updatesAndReturns<Employee>(employeeId) { invocations++ }
-                emits<DepartmentChanged> { }
+        When("The verify block does not hold") {
+            val verifying = {
+                changes verifyInOrder {
+                    updatesAndReturns<TestModel> { status() shouldBe null }
+                    emits<TestModelStatusChanged> { }
+                }
             }
 
-            Then("The block ran exactly once") {
-                invocations shouldBe 1
+            Then("The block failure surfaces") {
+                shouldThrow<AssertionError>(verifying)
+            }
+        }
+
+        When("updatesAndReturns is given an id that does not match") {
+            val verifying = {
+                with(equalityAware) {
+                    changes verifyInOrder {
+                        updatesAndReturns<TestModel>(randomTestModelId()) { }
+                        emits<TestModelStatusChanged> { }
+                    }
+                }
+            }
+
+            Then("The id mismatch surfaces") {
+                shouldThrow<AssertionError>(verifying)
             }
         }
     }
 
-    Given("Changes updating a model and returning an unrelated value") {
-        val employeeId = EmployeeId(randomUUID())
-        val employee = existingEmployee(employeeId).changeDepartment(newDep)
-        val changes = ChangesAccumulator().withUpdatedModel(employee).withResult(employeeId)
+    Given("A composed unit of work whose parent merges a newer instance over the child's change") {
+        val seed = createdTestModel("MLG", 420)
+        val child = { exCtx: ExecutionContext ->
+            object : ComposableUnitOfWork<TestPrincipal, DummyUow.Params, TestModel>(exCtx) {
+                override suspend fun tryPerform(principal: TestPrincipal, params: DummyUow.Params) = changes {
+                    add(seed)
+                }
+            }
+        }
 
-        When("updatesAndReturns verifies the updated model") {
-            val verifying = {
-                changes verifyInOrder {
-                    updatesAndReturns<Employee> { }
-                    emits<DepartmentChanged> { }
+        When("The parent returns the instance the child registered, superseded by the merge") {
+            val parent = object : DummyUow<TestModel>(executionContext) {
+                override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                    val added = execute(child, principal) { DummyUow.Params }
+                    update((added as TestModel.CreatedTestModel).activate())
+                    added
                 }
             }
 
-            Then("The result is reported as not being the updated model") {
+            Then("The result is accepted: same id, and the change carries the result's events") {
+                val changes = parent.tryPerform(TestPrincipal, DummyUow.Params)
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { id() shouldBe seed.id() }
+                    emits<TestModelCreated> { }
+                    emits<TestModelStatusChanged> { }
+                }
+            }
+        }
+
+        When("The parent seeds its result with roundtrip before the merge") {
+            val parent = object : DummyUow<TestModel>(executionContext) {
+                override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                    val added = execute(child, principal) { DummyUow.Params }
+                    val roundtripped = roundtrip { p -> p(added) }
+                    update((added as TestModel.CreatedTestModel).activate())
+                    roundtripped
+                }
+            }
+
+            Then("The stale roundtrip seed is accepted") {
+                val changes = parent.tryPerform(TestPrincipal, DummyUow.Params)
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { id() shouldBe seed.id() }
+                    emits<TestModelCreated> { }
+                    emits<TestModelStatusChanged> { }
+                }
+            }
+        }
+    }
+
+    Given("A unit of work adding a model and returning it through roundtrip") {
+        val added = createdTestModel("MLG", 420)
+        val uow = object : DummyUow<TestModel>(executionContext) {
+            override suspend fun tryPerform(principal: TestPrincipal, params: Params) = changes {
+                add(added)
+                roundtrip { p -> p(added) }
+            }
+        }
+
+        When("addsAndReturns verifies the change") {
+            Then("The roundtrip seed is accepted") {
+                val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { id() shouldBe added.id() }
+                    emits<TestModelCreated> { }
+                }
+            }
+        }
+    }
+
+    Given("A change whose result carries a mutation that was never registered") {
+        val added = createdTestModel("MLG", 420)
+        val changes = ChangesAccumulator()
+            .withAddedModel(added)
+            .withResult(added.changeParam1("NOT REGISTERED"))
+
+        When("addsAndReturns verifies the change") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { }
+                    emits<TestModelCreated> { }
+                }
+            }
+
+            Then("The unregistered events are named on both sides") {
                 val exception = shouldThrow<IllegalStateException>(verifying)
-                exception.message shouldContain "Result is not the updated model"
+                exception.message shouldContain "carries events the change does not"
+                exception.message shouldContain added.id().stringValue()
+                exception.message shouldContain "The change holds [TestModelCreated]"
+                exception.message shouldContain "the result holds [TestModelCreated, TestModelEvent1]"
+            }
+        }
+    }
+
+    Given("A change whose result has the same id but a different history") {
+        val id = randomTestModelId()
+        val updated = existingCreatedTestModel(id, "noscope", 360, V1).activate()
+        val divergent = existingCreatedTestModel(id, "noscope", 360, V1).activate()
+        val changes = ChangesAccumulator().withUpdatedModel(updated).withResult(divergent)
+
+        When("updatesAndReturns verifies the change") {
+            val verifying = {
+                changes verifyInOrder {
+                    updatesAndReturns<TestModel> { }
+                    emits<TestModelStatusChanged> { }
+                }
+            }
+
+            Then("The divergent history is reported") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "carries a different history"
+                exception.message shouldContain id.stringValue()
+            }
+        }
+    }
+
+    Given("A change whose result is an unrelated model of the same type") {
+        val added = createdTestModel("MLG", 420)
+        val unrelated = createdTestModel("MLG", 420)
+        val changes = ChangesAccumulator().withAddedModel(added).withResult(unrelated)
+
+        When("addsAndReturns verifies the change") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { }
+                    emits<TestModelCreated> { }
+                }
+            }
+
+            Then("Both ids and states are reported, pointing at verify order") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "the ids differ"
+                exception.message shouldContain added.id().stringValue()
+                exception.message shouldContain unrelated.id().stringValue()
+                exception.message shouldContain "CreatedTestModel[id = "
+                exception.message shouldContain "new, version = 0, events = [TestModelCreated]"
+                exception.message shouldContain "same order as the registered changes"
+            }
+        }
+    }
+
+    Given("A change whose result is null") {
+        val added = createdTestModel("MLG", 420)
+        val changes = ChangesAccumulator().withAddedModel(added).withResult<Any?>(null)
+
+        When("addsAndReturns verifies the change") {
+            val verifying = {
+                changes verifyInOrder {
+                    addsAndReturns<TestModel> { }
+                    emits<TestModelCreated> { }
+                }
+            }
+
+            Then("The result is reported as not being a model at all") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "Result is not a model at all"
+                exception.message shouldContain added.id().stringValue()
+                exception.message shouldContain "Result was [null]"
+            }
+        }
+    }
+
+    Given("A change whose result is neither a model nor of the right id") {
+        val added = createdTestModel("MLG", 420)
+        val changes = ChangesAccumulator().withAddedModel(added).withResult(added.id())
+
+        When("addsAndReturns is given a mismatching id as well") {
+            val verifying = {
+                with(equalityAware) {
+                    changes verifyInOrder {
+                        addsAndReturns<TestModel>(randomTestModelId()) { }
+                        emits<TestModelCreated> { }
+                    }
+                }
+            }
+
+            Then("The id check runs first, so the id mismatch is what surfaces") {
+                shouldThrow<AssertionError>(verifying)
+            }
+        }
+
+        When("addsAndReturns is given the matching id") {
+            val verifying = {
+                with(equalityAware) {
+                    changes verifyInOrder {
+                        addsAndReturns<TestModel>(added.id()) { }
+                        emits<TestModelCreated> { }
+                    }
+                }
+            }
+
+            Then("The result is reported as not being a model at all, naming its type") {
+                val exception = shouldThrow<IllegalStateException>(verifying)
+                exception.message shouldContain "Result is not a model at all"
+                exception.message shouldContain "Result was [TestModelId:"
             }
         }
     }


### PR DESCRIPTION
`addsAndReturns` and `updatesAndReturns` (and both `EqualityVerifierAware` overloads) invoked the caller's `verify` lambda twice: once against the UoW result, once against the recorded change. The spec DSL pops from deques, so a lambda with a side effect met a different state on the second pass. A nested `emits` drained its event on the first pass and failed on the second with `Expecting [ModelEvent] got nothing`, and nothing in the message pointed at the cause.

The lambda now runs once, against the recorded change. The result is then checked against that change: same model id, and the change's events hold the result's events, in order, from the same start. Id is what eva guarantees a caller receives, because `UnitOfWorkExecutor.roundtrippedResult` resolves a model result by id. The event check is the part an id alone cannot do: it rejects a result carrying a mutation the change never registered.

The pass sets are not comparable with the old behavior:

* Now rejected: returning an unregistered mutation, or an unrelated instance. Both passed silently before.
* Now accepted: a composed merge where the parent returns the child's superseded instance, and `roundtrip { p -> p(model) }` seeded before a later merge. Identity rejected these; both are runtime-correct.
* Now failing: a change raising two events asserted by a single nested `emits`. One `emits` asserts one event. The old green came from the doubled lambda draining both.

Measured downstream impact of a locally built eva carrying this and #323: 0 failures across 8263 hc-server tests and 3523 s2p tests. These functions are `inline`, so consumer specs must recompile to pick the check up.

Escape hatch for a verify block that needs side effects: `adds<M> { ... }` plus a separate `returns { }`.
