### PR TITLE
Check the type PersistedLookup was asked for

### DIFF
--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/Changes.kt
@@ -24,17 +24,25 @@ abstract class Changes<R> {
 /**
  * Resolves a model to its change-set instance by id: the flushed instance post-flush (top-level run),
  * the in-memory one under composition. Returns the argument unchanged when its id is not in the change set.
+ *
+ * The resolved instance can be a different subtype than the argument, because a composed child may have
+ * moved the model to another state. [invoke] is reified, so that is checked against the type the call
+ * site asks for: declare the state the change set holds, or a supertype of it, and a mismatch fails
+ * here with an explanation instead of surfacing as a cast error somewhere else.
  */
-interface PersistedLookup {
-    operator fun <M : Model<*, *>> invoke(model: M): M
-}
-
-// One PersistedLookup over a by-id resolver: persisted map at top level, in-memory change set under composition.
-internal class ChangeSetLookup(
-    private val resolve: (ModelId<out Comparable<*>>) -> Model<*, *>?,
-) : PersistedLookup {
-    @Suppress("UNCHECKED_CAST")
-    override fun <M : Model<*, *>> invoke(model: M): M = (resolve(model.id()) ?: model) as M
+class PersistedLookup internal constructor(
+    @PublishedApi internal val resolveById: (ModelId<out Comparable<*>>) -> Model<*, *>?,
+) {
+    inline operator fun <reified M : Model<*, *>> invoke(model: M): M {
+        val resolved = resolveById(model.id()) ?: return model
+        check(resolved is M) {
+            "Model [${model.id().stringValue()}] resolves to ${resolved::class.simpleName} in the " +
+                "change set, which is not the ${M::class.simpleName} this lookup was asked for. " +
+                "A composed change moved the model to another state: ask for that state, or for a " +
+                "type both share."
+        }
+        return resolved
+    }
 }
 
 class ChangesAccumulator private constructor(

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/UnitOfWorkExecutor.kt
@@ -307,7 +307,7 @@ class UnitOfWorkExecutor(
         if (builder != null) {
             val byId = persisted.associateBy { it.id() }
             @Suppress("UNCHECKED_CAST")
-            return builder(ChangeSetLookup { byId[it] }) as RESULT
+            return builder(PersistedLookup { byId[it] }) as RESULT
         }
         return roundtrippedResult(changes, persisted)
     }

--- a/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
+++ b/eva-uow/src/main/kotlin/com/razz/eva/uow/composable/ChangesDsl.kt
@@ -12,13 +12,12 @@ import com.razz.eva.uow.OtelAttributes.MODEL_ID
 import com.razz.eva.tracing.getEvaTracer
 import com.razz.eva.tracing.use
 import com.razz.eva.uow.AddModel
-import com.razz.eva.uow.ChangeSetLookup
+import com.razz.eva.uow.PersistedLookup
 import com.razz.eva.uow.Changes
 import com.razz.eva.uow.ChangesAccumulator
 import com.razz.eva.uow.ExecutionContext
 import com.razz.eva.uow.InstantiationContext
 import com.razz.eva.uow.NoopModel
-import com.razz.eva.uow.PersistedLookup
 import com.razz.eva.uow.UpdateModel
 import com.razz.eva.uow.UowParams
 import io.opentelemetry.api.trace.Span
@@ -42,7 +41,7 @@ class ChangesDsl internal constructor(
      */
     fun <R> roundtrip(build: (p: PersistedLookup) -> R): R {
         resultBuilder = build
-        return build(ChangeSetLookup { changes.changeFor(it)?.model })
+        return build(PersistedLookup { changes.changeFor(it)?.model })
     }
 
     fun <MID, E, M> add(model: M): M

--- a/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
+++ b/eva-uow/src/test/kotlin/com/razz/eva/uow/composable/ChangesDslSpec.kt
@@ -36,6 +36,7 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.shouldBeTypeOf
 import io.opentelemetry.api.OpenTelemetry
 import java.time.LocalDate
@@ -95,11 +96,7 @@ class ChangesDslSpec : FunSpec({
 
         // the builder rebuilds from whatever the persisted lookup resolves
         val persisted = existingCreatedTestModel(model0.id(), "PERSISTED", 999, V1).activate()
-        val lookup = object : PersistedLookup {
-            @Suppress("UNCHECKED_CAST")
-            override fun <M : com.razz.eva.domain.Model<*, *>> invoke(model: M): M =
-                (if (model.id() == model0.id()) persisted else model) as M
-        }
+        val lookup = PersistedLookup { id -> if (id == model0.id()) persisted else null }
         changes.resultBuilder.shouldNotBeNull().invoke(lookup) shouldBe RoundtripResult(persisted, "label")
     }
 
@@ -116,10 +113,22 @@ class ChangesDslSpec : FunSpec({
         val changes = uow.tryPerform(TestPrincipal, DummyUow.Params)
 
         // unrelated was never added; an empty persisted lookup returns it unchanged
-        val emptyLookup = object : PersistedLookup {
-            override fun <M : com.razz.eva.domain.Model<*, *>> invoke(model: M): M = model
-        }
+        val emptyLookup = PersistedLookup { null }
         changes.resultBuilder.shouldNotBeNull().invoke(emptyLookup) shouldBe RoundtripResult(unrelated, "label")
+    }
+
+    test("A lookup asked for a state the change set no longer holds says so") {
+        val model = existingCreatedTestModel(randomTestModelId(), "seed", 1, V1)
+        val activated = model.activate()
+        val lookup = PersistedLookup { activated }
+
+        val exception = shouldThrow<IllegalStateException> { lookup(model) }
+        exception.message.shouldNotBeNull() shouldContain "resolves to ActiveTestModel in the change set"
+        exception.message.shouldNotBeNull() shouldContain "not the CreatedTestModel this lookup was asked for"
+
+        // a type both states share resolves fine
+        val wide: com.razz.eva.domain.TestModel = model
+        lookup(wide) shouldBe activated
     }
 
     test("Should throw exception when new model updated without inherited change") {


### PR DESCRIPTION
`PersistedLookup.invoke` cast the resolved model to the caller's type without checking it:

```kotlin
override fun <M : Model<*, *>> invoke(model: M): M = (resolve(model.id()) ?: model) as M
```

`M` is erased, so the cast never fails there. It fails later, at whatever line uses the value, as a bare `ClassCastException`. That happens when a composed child moves the model to another state and `roundtrip { p -> p(model) }` asks for the state it had before.

`PersistedLookup` is now a final class with a reified `invoke`, so the check uses the type the call site asks for:

```
Model [7b8ab93c…] resolves to ActiveTestModel in the change set, which is not the
CreatedTestModel this lookup was asked for. A composed change moved the model to
another state: ask for that state, or for a type both share.
```

Asking for a type both states share still resolves and returns the new state, so this rejects only what would have thrown anyway.

Interface to class is a source break for implementors. There are none outside eva's own specs, where the two anonymous implementations become `PersistedLookup { … }` and `ChangeSetLookup` is deleted.
